### PR TITLE
refactor(cmark): convert InlineMathSpan tex function to method

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 target/
 .mooncakes/
+.moonagent/
+.env
 node_modules/

--- a/src/cmark/cmark.mbti
+++ b/src/cmark/cmark.mbti
@@ -10,8 +10,6 @@ let layout_empty : Node[String]
 
 fn layout_of_string(meta~ : @cmark_base.Meta = .., String) -> Node[String]
 
-fn tex(InlineMathSpan) -> String
-
 // Types and methods
 pub(all) enum Block {
   BlankLine(Node[String])

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -451,6 +451,6 @@ pub(all) struct InlineMathSpan {
 } derive(Eq, Show, ToJson)
 
 ///|
-pub fn tex(self : InlineMathSpan) -> String {
+pub fn InlineMathSpan::tex(self : Self) -> String {
   self.tex_layout.inner().map(Tight::to_string).join(" ")
 }


### PR DESCRIPTION
Convert the standalone `tex` function to a proper method `InlineMathSpan::tex`
on the `InlineMathSpan` type for better encapsulation and consistency with
MoonBit method conventions.

Changes:
- Remove standalone `tex` function from public interface (cmark.mbti)
- Convert to `InlineMathSpan::tex` method with proper Self type annotation
- Maintains the same functionality while improving type safety