### PR TITLE
style: replace deprecated `let null = Null` with `Json::null()`

### DIFF
--- a/src/cmark/README.mbt.md
+++ b/src/cmark/README.mbt.md
@@ -328,7 +328,7 @@ test "tables" {
     #||----------|----------|
     #|| Cell 1   | Cell 2   |
   let doc = @cmark.Doc::from_string(input, strict=false)
-  let null = Null
+  let null = Json::null()
   @json.inspect(doc, content={
     "nl": "\n",
     "block": {


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

Updated the deprecated null syntax in src/cmark/README.mbt.md to use the new 
Json::null() function instead of the deprecated Null constructor.

This change was made in response to the upcoming deprecation of the old syntax.