### PR TITLE
Fix all MoonBit deprecation warnings

### DIFF
--- a/src/char/text.mbt
+++ b/src/char/text.mbt
@@ -16,10 +16,10 @@ pub fn at_checked(s : @string.View, idx : Int) -> Result[Char, Int] {
     ((leading - 0xD800) * 0x400 + trailing - 0xDC00 + 0x10000).unsafe_to_char()
   }
 
-  let c1 = s.charcode_at(idx)
+  let c1 = s[idx]
   if is_leading_surrogate(c1) {
     guard idx + 1 < s.length() else { Err(c1) }
-    let c2 = s.charcode_at(idx + 1)
+    let c2 = s[idx + 1]
     Ok(code_point_of_surrogate_pair(c1, c2))
   } else if is_trailing_surrogate(c1) {
     Err(c1)
@@ -43,7 +43,7 @@ pub fn sub_includes(
   for i = first, k = 0 {
     guard i <= max_idx_s else { return false }
     guard k <= max_idx_a else { return true }
-    if s.charcode_at(i + k) == affix.charcode_at(k) {
+    if s[i + k] == affix[k] {
       continue i, k + 1
     }
     continue i + 1, 0
@@ -55,7 +55,7 @@ pub fn prev_char(s : @string.View, first~ : Int, before~ : Int) -> Char {
   guard first < before else { ' ' }
   let k = for start = before - 1; ; start = start - 1 {
     guard first <= start else { break first }
-    if s.charcode_at(start)
+    if s[start]
       is ('\u{0}'..='\u{7f}'
       | '\u{c2}'..='\u{df}'
       | '\u{e0}'..='\u{ef}'
@@ -63,13 +63,13 @@ pub fn prev_char(s : @string.View, first~ : Int, before~ : Int) -> Char {
       break start
     }
   }
-  s.char_at(k)
+  s.get_char(k).unwrap()
 }
 
 ///|
 pub fn next_char(s : @string.View, last~ : Int, after~ : Int) -> Char {
   guard after < last else { ' ' }
-  s.char_at(after + 1)
+  s.get_char(after + 1).unwrap()
 }
 
 ///|
@@ -98,13 +98,13 @@ pub fn utf_16_clean_raw(
         flush(last, start, k)
         break buf.to_string()
       }
-      if s.charcode_at(k) == '\u{0}' {
+      if s[k] == '\u{0}' {
         let next = k + 1
         flush(last, start, k)
         buf.write_char(rep)
         continue last, next, next
       }
-      if s.charcode_at(k).to_char() is Some(c) && c.is_ascii() {
+      if s[k].to_char() is Some(c) && c.is_ascii() {
         continue last, start, k + 1
       }
       match at_checked(s, k) {
@@ -126,10 +126,10 @@ pub fn utf_16_clean_raw(
     for last = last, first = first, k = k {
       break if k > last {
         s.substring(start=first, end=last + 1)
-      } else if s.charcode_at(k) == '\u{0}' {
+      } else if s[k] == '\u{0}' {
         buf.reset()
         clean(last, first, k)
-      } else if s.charcode_at(k).to_char() is Some(c) && c.is_ascii() {
+      } else if s[k].to_char() is Some(c) && c.is_ascii() {
         continue last, first, k + 1
       } else {
         match at_checked(s, k) {
@@ -155,8 +155,8 @@ pub fn utf_16_clean_raw(
     return buf.to_string()
   }
   let max = s.length() - 1
-  let last = @math.minimum(last, max)
-  let first = @math.maximum(first, 0)
+  let last = @cmp.minimum(last, max)
+  let first = @cmp.maximum(first, 0)
   if pad == 0 {
     return check(last, first, first)
   }
@@ -208,7 +208,7 @@ fn _utf_16_clean_unesc_unref(
       if k > last || k > num_start + 6 {
         return resolve(last, start, k)
       }
-      match s.charcode_at(k) {
+      match s[k] {
         ';' => {
           let next = k + 1
           if k == num_start {
@@ -236,7 +236,7 @@ fn _utf_16_clean_unesc_unref(
       if k > last || k > num_start + 7 {
         return resolve(last, start, k)
       }
-      match s.charcode_at(k) {
+      match s[k] {
         ';' => {
           let next = k + 1
           if k == num_start {
@@ -265,7 +265,7 @@ fn _utf_16_clean_unesc_unref(
       if k > last {
         return resolve(last, start, k)
       }
-      match s.charcode_at(k) {
+      match s[k] {
         ';' => {
           let name = s.substring(start=name_start, end=k)
           match html_named_entity(name) {
@@ -293,7 +293,7 @@ fn _utf_16_clean_unesc_unref(
         return buf.to_string()
       }
       let next = k + 1
-      match (s.charcode_at(k), do_unesc) {
+      match (s[k], do_unesc) {
         ('\u{0}', _) => {
           flush(last, start, k)
           buf.write_char(rep)
@@ -303,7 +303,7 @@ fn _utf_16_clean_unesc_unref(
           if next > last {
             continue last, start, next
           }
-          let nc = s.charcode_at(next).unsafe_to_char()
+          let nc = s[next].unsafe_to_char()
           if not(is_ascii_punctuation(nc)) {
             continue last, start, next
           }
@@ -316,10 +316,10 @@ fn _utf_16_clean_unesc_unref(
           if k + 2 > last {
             continue last, start, next
           }
-          match s.charcode_at(next) {
+          match s[next] {
             '#' => {
               let next = next + 1
-              match s.charcode_at(next) {
+              match s[next] {
                 'x' | 'X' => {
                   let next = next + 1
                   return try_entity_hex(last, start, next, next, 0)
@@ -363,13 +363,13 @@ fn _utf_16_clean_unesc_unref(
 
   guard first <= last else { return "" }
   let max = s.length() - 1
-  let last = @math.minimum(last, max)
-  let first = @math.maximum(first, 0)
+  let last = @cmp.minimum(last, max)
+  let first = @cmp.maximum(first, 0)
   for start = first, k = first {
     guard k <= last else {
       break s.substring(start=first, end=first + last - start + 1)
     }
-    match (s.charcode_at(k), do_unesc) {
+    match (s[k], do_unesc) {
       ('\\', true) | ('&', _) | ('\u{0}', _) => {
         buf.reset()
         break resolve(last, start, k)

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -176,7 +176,7 @@ pub fn CodeBlock::make_fence(self : CodeBlock) -> (Char, Count) {
   for n in self.code {
     let c = n.v
     let mut k = 0
-    while k < c.length() && c.charcode_at(k) == ch.to_int() {
+    while k < c.length() && c[k] == ch.to_int() {
       k += 1
     }
     if k != 0 {
@@ -192,7 +192,7 @@ pub fn CodeBlock::language_of_info_string(s : String) -> (String, String)? {
   guard not(s.is_empty()) else { None }
   let max = s.length() - 1
   let white = for i = 0; ; i = i + 1 {
-    if i > max || @char.is_ascii_whitespace(s.char_at(i)) {
+    if i > max || @char.is_ascii_whitespace(s.get_char(i).unwrap()) {
       break i
     }
   }
@@ -381,7 +381,7 @@ pub fn Footnote::new(
   label : Label,
   block : Block,
 ) -> Footnote {
-  let defined_label = defined_label.or(Some(label))
+  let defined_label = defined_label.unwrap_or(Some(label))
   { indent, label, defined_label, block }
 }
 
@@ -438,8 +438,8 @@ pub fn Table::new(
   for row in rows {
     match row.0.v {
       Header(cols) | Data(cols) =>
-        col_count = @math.maximum(col_count, cols.length())
-      Sep(cols) => col_count = @math.maximum(col_count, cols.length())
+        col_count = @cmp.maximum(col_count, cols.length())
+      Sep(cols) => col_count = @cmp.maximum(col_count, cols.length())
     }
   }
   { indent, rows, col_count }
@@ -454,12 +454,12 @@ fn Table::parse_sep_row(
     (acc, [(Text({ v, meta }), TableCellLayout(("", ""))), .. cs]) => {
       guard not(v.is_empty()) else { None }
       let max = v.length() - 1
-      let first_colon = v.charcode_at(0) == ':'
-      let last_colon = v.charcode_at(max) == ':'
+      let first_colon = v[0] == ':'
+      let last_colon = v[max] == ':'
       let first = if first_colon { 1 } else { 0 }
       let last = if last_colon { max - 1 } else { max }
       for i in first..=last {
-        guard v.charcode_at(i) == '-' else { break None }
+        guard v[i] == '-' else { break None }
       } else {
         let count = last - first + 1
         let sep = match (first_colon, last_colon) {

--- a/src/cmark/block_struct.mbt
+++ b/src/cmark/block_struct.mbt
@@ -32,7 +32,7 @@ fn Parser::update_next_non_blank(self : Parser) -> Unit {
       self.next_non_blank = k
       self.next_non_blank_col = col
     } else {
-      match s.charcode_at(k) {
+      match s[k] {
         ' ' => continue s, last, k + 1, col + 1
         '\t' => continue s, last, k + 1, next_tab_stop(col)
         _ => {
@@ -50,7 +50,7 @@ fn Parser::accept_cols(self : Parser, count~ : Int) -> Unit {
     break if count == 0 {
       self.curr_char = k
       self.curr_char_col = col
-    } else if self.i.charcode_at(k) != '\t' {
+    } else if self.i[k] != '\t' {
       continue count - 1, k + 1, col + 1
     } else {
       let col1 = next_tab_stop(col)
@@ -69,13 +69,13 @@ fn Parser::accept_cols(self : Parser, count~ : Int) -> Unit {
 
 ///| https://spec.commonmark.org/current/#block-quote-marker
 fn Parser::match_and_accept_block_quote(self : Parser) -> Bool {
-  if self.end_of_line() || self.i.charcode_at(self.curr_char) != '>' {
+  if self.end_of_line() || self.i[self.curr_char] != '>' {
     return false
   }
   let next_is_blank = {
     let next = self.curr_char + 1
     next <= self.curr_line_last_char &&
-    @char.is_ascii_blank(self.i.char_at(next))
+    @char.is_ascii_blank(self.i.get_char(next).unwrap())
   }
   self.accept_cols(
     count=1 + next_is_blank.to_int(), // We eat a space
@@ -95,7 +95,7 @@ fn Parser::accept_list_marker_and_indent(
   let min_indent = if self.only_blanks() || indent > 4 {
     1
   } else {
-    @math.minimum(indent, 4)
+    @cmp.minimum(indent, 4)
   }
   self.accept_cols(count=min_indent)
   min_indent
@@ -305,7 +305,7 @@ fn Parser::fenced_code_block(
   }
   let opening_fence = self.curr_line_span(first=fence_first, last=layout_last)
   let fence = (
-    self.i.charcode_at(fence_first).unsafe_to_char(),
+    self.i[fence_first].unsafe_to_char(),
     fence_last - fence_first + 1,
   )
   let fence = { indent, opening_fence, fence, info_string, closing_fence: None }
@@ -416,7 +416,7 @@ fn Parser::parse_link_ref_definition(
     None
   }
   let colon = last + 1
-  guard colon <= line.last && self.i.charcode_at(colon) == ':' else { None }
+  guard colon <= line.last && self.i[colon] == ':' else { None }
   let label = Parser::label_of_spans(self, key~, spans[:])
   let (lines, line, label, start) = (lines, line, label, colon + 1)
   guard self.first_non_blank_over_nl(next_line~, lines, line, start~)
@@ -477,7 +477,7 @@ fn Parser::parse_link_ref_definition(
       (
         lines1,
         after_dest,
-        self.i.charcode_at(start1).unsafe_to_char(),
+        self.i[start1].unsafe_to_char(),
         Some(t),
         after_title,
         { ..line1, last, },
@@ -699,7 +699,7 @@ fn Parser::match_line_type(
   }
   let start = self.curr_char
   let last = self.curr_line_last_char
-  match self.i.charcode_at(start) {
+  match self.i[start] {
     // Early dispatch shaves a few ms but may not be worth doing vs 
     // testing all the cases in sequences.
     '>' => {
@@ -1068,7 +1068,7 @@ fn Parser::try_add_to_fenced_code_block(
       match
         @cmark_base.FencedCodeBlockContinue::new(self.i, fence~, last~, start~) {
         Code => {
-          let strip = @math.minimum(indent, self.curr_indent())
+          let strip = @cmp.minimum(indent, self.curr_indent())
           let (pad, first) = self.accept_code_indent(count=strip)
           ls.push((pad, self.curr_line_span(first~, last~)))
           bs.push(CodeBlock(Fenced({ ..b, code: ls })))
@@ -1329,9 +1329,7 @@ fn Parser::add_line(self : Parser, bs : Array[BlockStruct]) -> Unit {
 fn Parser::get_first_line(self : Parser) -> String {
   let max = self.i.length() - 1
   let mut k = 0
-  let last_char = while k <= max &&
-                        self.i.charcode_at(k) != '\r' &&
-                        self.i.charcode_at(k) != '\n' {
+  let last_char = while k <= max && self.i[k] != '\r' && self.i[k] != '\n' {
     k += 1
   } else {
     // If the line is empty, we have -1
@@ -1340,11 +1338,11 @@ fn Parser::get_first_line(self : Parser) -> String {
   self.curr_line_last_char = last_char
   self.update_next_non_blank()
   // Return first used newline (or "\n" if there is none)
-  if k > max || self.i.charcode_at(k) == '\n' {
+  if k > max || self.i[k] == '\n' {
     return "\n"
   }
   let next = k + 1
-  if next <= max && self.i.charcode_at(next) == '\n' {
+  if next <= max && self.i[next] == '\n' {
     return "\r\n"
   }
   "\r"
@@ -1358,18 +1356,18 @@ fn Parser::get_next_line(self : Parser) -> Bool {
   }
   let first_char = {
     let nl = self.curr_line_last_char + 1
-    if self.i.charcode_at(nl) == '\n' {
+    if self.i[nl] == '\n' {
       nl + 1
     } else {
       let mut next = nl + 1
-      if next <= max && self.i.charcode_at(next) == '\n' {
+      if next <= max && self.i[next] == '\n' {
         next += 1
       }
       next
     }
   }
   let last_char = for k = first_char
-                      k <= max && not(self.i.charcode_at(k) is ('\r' | '\n'))
+                      k <= max && not(self.i[k] is ('\r' | '\n'))
                       k = k + 1 {
 
   } else {
@@ -1571,7 +1569,7 @@ fn Parser::block_struct_to_table(
       let meta = self.meta(self.text_loc_of_span(row))
       let row1 = { ..row, first: row.first + 1, last: row.last }
       let cols = self.parse_table_row(row1)
-      let col_count = @math.maximum(col_count, cols.length())
+      let col_count = @cmp.maximum(col_count, cols.length())
       let (r, last_was_sep) = match Table::parse_sep_row(cols[:]) {
         Some(seps) => ({ v: Sep(seps), meta }, true)
         None => {

--- a/src/cmark/inline.mbt
+++ b/src/cmark/inline.mbt
@@ -170,7 +170,7 @@ pub fn Inline::id(
     if k > max {
       break buf.to_string()
     }
-    match s.char_at(k) {
+    match s.get_char(k).unwrap() {
       ' ' | '\t' as prev_ccode => continue max, prev_ccode, k + 1
       '_' | '-' as c => {
         collapse_blanks(prev)
@@ -179,7 +179,7 @@ pub fn Inline::id(
       }
       c => {
         collapse_blanks(prev)
-        let mut u = s.char_at(k)
+        let mut u = s.get_char(k).unwrap()
         if u == '\u{0000}' {
           u = @char.rep
         }
@@ -300,7 +300,7 @@ pub fn InlineCodeSpan::from_string(
       }
       break (bt_counts, layout)
     }
-    let sk = s.charcode_at(k)
+    let sk = s[k]
     if sk == '`' {
       continue bt_counts, acc, max, btc + 1, start, k + 1
     }
@@ -311,7 +311,7 @@ pub fn InlineCodeSpan::from_string(
       continue bt_counts, acc, max, 0, start, k + 1
     }
     BlockLine::flush_tight(meta~, s, start, k - 1, acc)
-    let start = if k + 1 <= max && sk == '\r' && s.charcode_at(k + 1) == '\n' {
+    let start = if k + 1 <= max && sk == '\r' && s[k + 1] == '\n' {
       k + 2
     } else {
       k + 1
@@ -420,7 +420,7 @@ pub fn InlineLink::is_unsafe(l : String) -> Bool {
       None => j
     }
     let allowed = ["image/gif", "image/png", "image/jpeg", "image/webp"]
-    allowed.contains(l.substring(start=5, end=@math.minimum(j, k)))
+    allowed.contains(l.substring(start=5, end=@cmp.minimum(j, k)))
   }
   let lower = @casefold.casefold(l)
   lower.has_prefix("javascript:") ||

--- a/src/cmark/inline_struct.mbt
+++ b/src/cmark/inline_struct.mbt
@@ -243,8 +243,7 @@ fn Token::newline(
   // https://spec.commonmark.org/current/#hard-line-breaks
   let { first, last, .. } = prev_line
   let non_space = @cmark_base.rev_drop_spaces(s, first~, start=last)
-  let (start, break_ty) = if non_space == last &&
-    s.charcode_at(non_space) == '\\' {
+  let (start, break_ty) = if non_space == last && s[non_space] == '\\' {
     (non_space, Hard)
   } else {
     let start = non_space + 1
@@ -275,7 +274,7 @@ fn tokens_try_add_image_link_start(
   start~ : Int,
 ) -> Int {
   let next = start + 1
-  guard next <= line.last && s.charcode_at(next) == '[' else { next }
+  guard next <= line.last && s[next] == '[' else { next }
   toks.push(LinkStart({ start, image: true }))
   next + 1
 }
@@ -288,7 +287,7 @@ fn tokens_try_add_emphasis(
   start~ : Int,
 ) -> Int {
   let { first, last, .. } = line
-  let char = s.charcode_at(start).unsafe_to_char()
+  let char = s[start].unsafe_to_char()
   let run_last = @cmark_base.run_of(char~, last~, s, start=start + 1)
   let count = run_last - start + 1
   let prev_char = @char.prev_char(s, first~, before=start)
@@ -328,7 +327,7 @@ fn tokens_try_add_strikethrough_marks(
   start~ : Int,
 ) -> Int {
   let { first, last, .. } = line
-  let char = s.charcode_at(start).unsafe_to_char()
+  let char = s[start].unsafe_to_char()
   let run_last = @cmark_base.run_of(char~, s, last~, start=start + 1)
   let count = run_last - start + 1
   let next = run_last + 1
@@ -349,7 +348,7 @@ fn tokens_try_add_math_span_marks(
   start~ : Int,
 ) -> Int {
   let { first, last, .. } = line
-  let char = s.charcode_at(start).unsafe_to_char()
+  let char = s[start].unsafe_to_char()
   let run_last = @cmark_base.run_of(char~, s, last~, start=start + 1)
   let count = run_last - start + 1
   let next = run_last + 1
@@ -386,7 +385,7 @@ fn tokenize(
         }
       }
     }
-    let next = match s.charcode_at(k) {
+    let next = match s[k] {
       '\\' => continue lines, line, not(prev_bslash), k + 1
       '`' => tokens_add_backtick(toks, s, line, prev_bslash~, start=k)
       _ if prev_bslash => k + 1
@@ -558,7 +557,7 @@ fn Parser::emphasis_token(
   emph : Inline,
 ) -> Token {
   let text_loc = self.text_loc_of_lines(first~, last~, first_line~, last_line~)
-  let delim = self.i.charcode_at(first).unsafe_to_char()
+  let delim = self.i[first].unsafe_to_char()
   let emph = { v: { delim, inline: emph }, meta: self.meta(text_loc) }
   let inline = if strong { StrongEmphasis(emph) } else { Emphasis(emph) }
   Inline({ start: first, inline, endline: last_line, next: last + 1 })
@@ -892,7 +891,7 @@ fn Parser::try_inline_link_remainder(
             (
               line,
               after_dest,
-              self.i.charcode_at(start).unsafe_to_char(),
+              self.i[start].unsafe_to_char(),
               Some(title),
               last + 1,
             )
@@ -907,8 +906,8 @@ fn Parser::try_inline_link_remainder(
       line,
       start~,
     )
-    .or((line, [], start))
-  if last > line.last || self.i.charcode_at(last) != ')' {
+    .unwrap_or((line, [], start))
+  if last > line.last || self.i[last] != ')' {
     return None
   }
   let layout : LinkDefinitionLayout = {
@@ -1015,7 +1014,7 @@ fn Parser::try_link_def(
   let link = if next > line.last {
     self.try_shortcut_reflink(start_rev_toks, start_line, image~, start~)
   } else {
-    match self.i.charcode_at(next) {
+    match self.i[next] {
       '(' =>
         match
           self.try_inline_link_remainder(rev_toks, line, image~, start=next) {
@@ -1030,7 +1029,7 @@ fn Parser::try_link_def(
         }
       '[' => {
         let next1 = next + 1
-        if next1 <= line.last && self.i.charcode_at(next1) == ']' {
+        if next1 <= line.last && self.i[next1] == ']' {
           self.try_collapsed_reflink(start_rev_toks, start_line, image~, start~)
         } else {
           let r = self.try_full_reflink_remainder(
@@ -1578,7 +1577,7 @@ fn Parser::start_col(
   match self.find_pipe(line, before~, k) {
     Err(text) => Start(bbefore, [text])
     Ok((text, bafter, k)) => {
-      let text = text.or_else(fn() {
+      let text = text.unwrap_or_else(fn() {
         let l = self.text_loc_of_span({ ..line, first: k, last: k - 1 })
         Inlines({ v: [], meta: self.meta(l) })
       })

--- a/src/cmark/mapper.mbt
+++ b/src/cmark/mapper.mbt
@@ -89,7 +89,7 @@ pub fn Mapper::map_inline(self : Mapper, i : Inline) -> Inline? {
     | Text(_)
     | ExtMathSpan(_) => Some(i)
     Image({ v, meta }) => {
-      let text = self.map_inline(v.text).or(Inline::empty())
+      let text = self.map_inline(v.text).unwrap_or(Inline::empty())
       Some(Image({ v: { ..v, text, }, meta }))
     }
     Link({ v, meta }) => {
@@ -132,13 +132,13 @@ pub fn Mapper::map_block(self : Mapper, b : Block) -> Block? {
     Heading({ v, meta }) => {
       let inline = self
         .map_inline(v.inline)
-        .or(Inlines({ v: [], meta: Meta::none() }))
+        .unwrap_or(Inlines({ v: [], meta: Meta::none() }))
       Some(Heading({ v: { ..v, inline, }, meta }))
     }
     BlockQuote({ v, meta }) => {
       let block = self
         .map_block(v.block)
-        .or(Blocks({ v: [], meta: Meta::none() }))
+        .unwrap_or(Blocks({ v: [], meta: Meta::none() }))
       Some(BlockQuote({ v: { ..v, block, }, meta }))
     }
     Blocks({ v, meta }) =>
@@ -165,7 +165,7 @@ pub fn Mapper::map_block(self : Mapper, b : Block) -> Block? {
     ExtFootnoteDefinition({ v, meta }) => {
       let block = self
         .map_block(v.block)
-        .or_else(fn() { Blocks(Node::new([])) }) // Can be empty
+        .unwrap_or_else(fn() { Blocks(Node::new([])) }) // Can be empty
       Some(ExtFootnoteDefinition({ v: { ..v, block, }, meta }))
     }
     ExtTable({ v, meta }) => {
@@ -196,7 +196,7 @@ pub fn Mapper::map_block(self : Mapper, b : Block) -> Block? {
 
 ///|
 pub fn Mapper::map_doc(self : Mapper, d : Doc) -> Doc {
-  let map_block = fn(b) { self.map_block(b).or(Block::empty()) }
+  let map_block = fn(b) { self.map_block(b).unwrap_or(Block::empty()) }
   let map_def = fn(b : LabelDef) {
     guard b is FootnoteDef({ v, meta }) else { b }
     let block = map_block(v.block)

--- a/src/cmark_base/autolink.mbt
+++ b/src/cmark_base/autolink.mbt
@@ -7,19 +7,17 @@ pub fn autolink_email(s : String, last~ : Int = -1, start~ : Int = 0) -> Last? {
   }
 
   fn label_seq(last : Int, k : Int) -> Int? {
-    guard k <= last &&
-      s.charcode_at(k).to_char() is Some(c) &&
-      @char.is_ascii_alphanum(c) else {
+    guard k <= last && s[k].to_char() is Some(c) && @char.is_ascii_alphanum(c) else {
       return None
     }
     for c = 1, k = k + 1 {
       guard k <= last else { break None }
-      let sk = s.charcode_at(k).unsafe_to_char()
+      let sk = s[k].unsafe_to_char()
       if char_is_alphanum_or_hyp(sk) && c <= 63 {
         continue c + 1, k + 1
       }
       guard c <= 63 &&
-        s.charcode_at(k - 1).to_char() is Some(c) &&
+        s[k - 1].to_char() is Some(c) &&
         @char.is_ascii_alphanum(c) else {
         break None
       }
@@ -31,15 +29,13 @@ pub fn autolink_email(s : String, last~ : Int = -1, start~ : Int = 0) -> Last? {
     }
   }
 
-  guard start <= last || s.charcode_at(start) == '<' else { None }
+  guard start <= last || s[start] == '<' else { None }
   for k in (start + 1)..=last {
-    let sk = s.charcode_at(k).unsafe_to_char()
+    let sk = s[k].unsafe_to_char()
     if char_is_atext_plus_dot(sk) {
       continue
     }
-    if sk == '@' &&
-      s.charcode_at(k - 1).to_char() is Some(c) &&
-      char_is_atext_plus_dot(c) {
+    if sk == '@' && s[k - 1].to_char() is Some(c) && char_is_atext_plus_dot(c) {
       break label_seq(last, k + 1)
     }
     break None
@@ -60,7 +56,7 @@ pub fn autolink_uri(s : String, last~ : Int = -1, start~ : Int = 0) -> Last? {
   }
   let rest = fn(s : String, last, k) {
     for k in k..=last {
-      let sk = s.charcode_at(k).unsafe_to_char()
+      let sk = s[k].unsafe_to_char()
       guard not(char_is_uri(sk)) else { continue }
       break if sk == '>' { Some(k) } else { None }
     } else {
@@ -69,13 +65,13 @@ pub fn autolink_uri(s : String, last~ : Int = -1, start~ : Int = 0) -> Last? {
   }
   let next = start + 1
   guard next <= last &&
-    s.charcode_at(start) == '<' &&
-    s.charcode_at(next).unsafe_to_char().is_ascii_alphabetic() else {
+    s[start] == '<' &&
+    s[next].unsafe_to_char().is_ascii_alphabetic() else {
     return None
   }
   for c = 1, k = next + 1 {
     guard k <= last else { break None }
-    let sk = s.charcode_at(k).unsafe_to_char()
+    let sk = s[k].unsafe_to_char()
     if char_is_scheme(sk) && c <= 32 {
       continue c + 1, k + 1
     }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -50,7 +50,7 @@ pub fn LineType::thematic_break(
   if start > last {
     return Nomatch
   }
-  match s.charcode_at(start) {
+  match s[start] {
     '-' | '_' | '*' =>
       for s = s, last = last, count = 1, prev = start, k = start + 1 {
         break if k > last {
@@ -59,9 +59,9 @@ pub fn LineType::thematic_break(
           } else {
             ThematicBreakLine(prev)
           }
-        } else if s.charcode_at(k) == s.charcode_at(prev) {
+        } else if s[k] == s[prev] {
           continue s, last, count + 1, k, k + 1
-        } else if s.charcode_at(k) is (' ' | '\t') {
+        } else if s[k] is (' ' | '\t') {
           continue s, last, count, prev, k + 1
         } else {
           Nomatch
@@ -78,7 +78,7 @@ pub fn LineType::atx_heading(
   start~ : CharCodePos,
 ) -> LineType {
   fn skip_hashes(s : String, last, k) {
-    for k = k; k <= last && s.charcode_at(k) == '#'; k = k + 1 {
+    for k = k; k <= last && s[k] == '#'; k = k + 1 {
 
     } else {
       k
@@ -87,7 +87,7 @@ pub fn LineType::atx_heading(
 
   fn find_end(s : String, last, k) { // Blank on k, last + 1 if blank* [#+] blank*
     let after_blank = first_non_blank(s, last~, start=k + 1)
-    if after_blank > last || s.charcode_at(after_blank) != '#' {
+    if after_blank > last || s[after_blank] != '#' {
       return after_blank
     }
     let after_hash = skip_hashes(s, last, after_blank + 1)
@@ -102,7 +102,7 @@ pub fn LineType::atx_heading(
   fn content(s : String, last, k) {
     for s = s, last = last, k = k {
       guard k <= last else { break k - 1 }
-      guard s.charcode_at(k) is (' ' | '\t') else { continue s, last, k + 1 }
+      guard s[k] is (' ' | '\t') else { continue s, last, k + 1 }
       let end1 = find_end(s, last, k)
       guard end1 <= last else { break k - 1 }
       continue s, last, end1
@@ -113,7 +113,7 @@ pub fn LineType::atx_heading(
     if k > last {
       return AtxHeadingLine(acc, k, k, last)
     }
-    if s.charcode_at(k) == '#' {
+    if s[k] == '#' {
       if acc < 6 {
         return level(s, last, acc + 1, k + 1)
       } else {
@@ -127,7 +127,7 @@ pub fn LineType::atx_heading(
     if first == k {
       return Nomatch // Need a blank
     }
-    let last = if s.charcode_at(first) != '#' {
+    let last = if s[first] != '#' {
       content(s, last, first + 1)
     } else {
       let end1 = find_end(s, last, first - 1) // Start on blank
@@ -140,7 +140,7 @@ pub fn LineType::atx_heading(
     AtxHeadingLine(acc, k, first, last)
   }
 
-  if start > last || s.charcode_at(start) != '#' {
+  if start > last || s[start] != '#' {
     return Nomatch
   }
   level(s, last, 1, start + 1)
@@ -155,21 +155,15 @@ pub fn LineType::setext_heading_underline(
   let level = fn(c) { 2 - (c == '=').to_int() }
   fn underline(s : String, last, start, k) {
     if k > last {
-      return SetextUnderlineLine(
-        level(s.charcode_at(start).unsafe_to_char()),
-        k - 1,
-      )
+      return SetextUnderlineLine(level(s[start].unsafe_to_char()), k - 1)
     }
-    if s.charcode_at(k) == s.charcode_at(start) {
+    if s[k] == s[start] {
       return underline(s, last, start, k + 1)
     }
-    guard s.charcode_at(k) is (' ' | '\t') else { return Nomatch }
+    guard s[k] is (' ' | '\t') else { return Nomatch }
     let end_blank = first_non_blank(s, last~, start=k + 1)
     if end_blank > last {
-      return SetextUnderlineLine(
-        level(s.charcode_at(start).unsafe_to_char()),
-        k - 1,
-      )
+      return SetextUnderlineLine(level(s[start].unsafe_to_char()), k - 1)
     }
     Nomatch
   }
@@ -177,7 +171,7 @@ pub fn LineType::setext_heading_underline(
   if start > last {
     return Nomatch
   }
-  if s.charcode_at(start) != '-' && s.charcode_at(start) != '=' {
+  if s[start] != '-' && s[start] != '=' {
     return Nomatch
   }
   underline(s, last, start, start + 1)
@@ -190,7 +184,7 @@ pub fn LineType::fenced_code_block_start(
   start~ : CharCodePos,
 ) -> LineType {
   fn info(s : String, last, nobt, info_first, k) {
-    let sk = s.charcode_at(k)
+    let sk = s[k]
     guard k <= last else { Some((info_first, last)) }
     guard not(nobt && sk == '`') else { None }
     guard sk is (' ' | '\t') else { info(s, last, nobt, info_first, k + 1) }
@@ -201,7 +195,7 @@ pub fn LineType::fenced_code_block_start(
 
   fn fence(s : String, last, fence_first, k) {
     for s = s, last = last, fence_first = fence_first, k = k {
-      if k <= last && s.charcode_at(k) == s.charcode_at(fence_first) {
+      if k <= last && s[k] == s[fence_first] {
         continue s, last, fence_first, k + 1
       }
       let fence_last = k - 1
@@ -212,13 +206,7 @@ pub fn LineType::fenced_code_block_start(
         if after_blank > last {
           None
         } else {
-          guard info(
-              s,
-              last,
-              s.charcode_at(fence_first) == '`',
-              after_blank,
-              after_blank,
-            )
+          guard info(s, last, s[fence_first] == '`', after_blank, after_blank)
             is Some(i) else {
             break None
           }
@@ -234,11 +222,11 @@ pub fn LineType::fenced_code_block_start(
   }
   for s = s, first = start, last = last, k = start {
     guard k <= last else { break Nomatch }
-    if k - first + 1 < 4 && s.charcode_at(k) == ' ' {
+    if k - first + 1 < 4 && s[k] == ' ' {
       continue s, first, last, k + 1
     }
-    guard s.charcode_at(k) is ('~' | '`') else { break Nomatch }
-    break fence(s, last, k, k + 1).or(Nomatch)
+    guard s[k] is ('~' | '`') else { break Nomatch }
+    break fence(s, last, k, k + 1).unwrap_or(Nomatch)
   }
 }
 
@@ -264,7 +252,7 @@ pub fn FencedCodeBlockContinue::new(
   let (fc, fcount) = fence
   fn fence(s : String, last, fence_first, k) {
     for s = s, last = last, fence_first = fence_first, k = k {
-      if k <= last && s.charcode_at(k).unsafe_to_char() == fc {
+      if k <= last && s[k].unsafe_to_char() == fc {
         continue s, last, fence_first, k + 1
       }
       let fence_last = k - 1
@@ -277,12 +265,12 @@ pub fn FencedCodeBlockContinue::new(
 
   for s = s, first = start, last = last, k = start {
     guard k <= last else { break Code } // Short blank line
-    let sk = s.charcode_at(k).unsafe_to_char()
+    let sk = s[k].unsafe_to_char()
     if k - first + 1 < 4 && sk == ' ' {
       continue s, first, last, k + 1
     }
     guard sk == fc else { break Code }
-    break fence(s, last, k, k + 1).or(Code)
+    break fence(s, last, k, k + 1).unwrap_or(Code)
   }
 }
 
@@ -323,7 +311,7 @@ fn LineType::html_block_start_2(
   start~ : CharCodePos,
 ) -> LineType {
   let next = start + 3 // 3 first chars checked
-  if next > last || s.charcode_at(next) != '-' {
+  if next > last || s[next] != '-' {
     return Nomatch
   }
   HtmlBlockLine(EndStr("-->"))
@@ -375,17 +363,17 @@ pub fn LineType::html_block_start(
   start~ : CharCodePos,
 ) -> LineType {
   let next = start + 1
-  if next > last || s.charcode_at(start) != '<' {
+  if next > last || s[start] != '<' {
     return Nomatch
   }
-  match s.charcode_at(next).unsafe_to_char() {
+  match s[next].unsafe_to_char() {
     '?' => HtmlBlockLine(EndStr("?>")) // 3
     '!' => {
       let next = next + 1
       if next > last {
         return Nomatch
       }
-      match s.charcode_at(next).unsafe_to_char() {
+      match s[next].unsafe_to_char() {
         '[' => LineType::html_block_start_5(s, last~, start~)
         '-' => LineType::html_block_start_2(s, last~, start~)
         c =>
@@ -400,8 +388,7 @@ pub fn LineType::html_block_start(
       guard c.is_ascii_alphabetic() || c == '/' else { return Nomatch }
       let tag_first = if c == '/' { next + 1 } else { next }
       let tag_last = for s = s, last = last, i = tag_first {
-        if i > last ||
-          not(s.charcode_at(i).unsafe_to_char().is_ascii_alphabetic()) {
+        if i > last || not(s[i].unsafe_to_char().is_ascii_alphabetic()) {
           break i - 1
         }
         continue s, last, i + 1
@@ -409,7 +396,7 @@ pub fn LineType::html_block_start(
       let tag = s.substring(start=tag_first, end=tag_last + 1).to_lower()
       let is_open_end = {
         let n = tag_last + 1
-        n > last || s.charcode_at(n) is (' ' | '\t' | '>')
+        n > last || s[n] is (' ' | '\t' | '>')
       }
       let is_open_close_end = is_open_end ||
         (
@@ -442,16 +429,14 @@ fn LineType::html_block_end_cond_1(
   let lower_s = s.to_lower()
   for last = last, k = start {
     guard k + 3 <= last else { break false }
-    guard s.charcode_at(k) == '<' && s.charcode_at(k + 1) == '/' else {
-      continue last, k + 1
-    }
+    guard s[k] == '<' && s[k + 1] == '/' else { continue last, k + 1 }
     let next = k + 2
     let is_end_tag = {
       let lower_s_sub = lower_s.substring(start=next)
-      match s.charcode_at(next) {
+      match s[next] {
         'p' => lower_s_sub.has_prefix("pre>")
         's' =>
-          if s.charcode_at(k + 3) == 't' {
+          if s[k + 3] == 't' {
             lower_s_sub.has_prefix("style>")
           } else {
             lower_s_sub.has_prefix("script>")
@@ -485,12 +470,12 @@ pub fn LineType::ext_table_row(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> LineType {
-  guard start <= last && s.charcode_at(start) == '|' else { Nomatch }
+  guard start <= last && s[start] == '|' else { Nomatch }
   let first = start + 1
   let last_nb = last_non_blank(s, first~, start=last)
   let before = last_nb - 1
-  guard last_nb >= first && s.charcode_at(last_nb) == '|' else { Nomatch }
-  guard before < first || s.charcode_at(before) != '\\' else { Nomatch }
+  guard last_nb >= first && s[last_nb] == '|' else { Nomatch }
+  guard before < first || s[before] != '\\' else { Nomatch }
   ExtTableRow(last_nb)
 }
 
@@ -502,14 +487,10 @@ pub fn LineType::ext_footnote_label(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> LineType {
-  guard start <= last &&
-    s.charcode_at(start) == '[' &&
-    s.charcode_at(start + 1) == '^' else {
-    Nomatch
-  }
+  guard start <= last && s[start] == '[' && s[start + 1] == '^' else { Nomatch }
   let rbrack = first_non_escaped_char(']', s, last~, start=start + 2)
   let colon = rbrack + 1
-  guard colon <= last && s.charcode_at(colon) == ':' && colon - start + 1 >= 5 else {
+  guard colon <= last && s[colon] == ':' && colon - start + 1 >= 5 else {
     Nomatch
   }
   // Get the normalized label
@@ -533,10 +514,10 @@ pub fn could_be_link_ref_definition(
   }
   for s = s, first = start, last = last, k = start {
     guard k <= last else { break false }
-    if k - first + 1 < 4 && s.charcode_at(k) == ' ' {
+    if k - first + 1 < 4 && s[k] == ' ' {
       continue s, first, last, k + 1
     }
-    break s.charcode_at(k) == '['
+    break s[k] == '['
   }
 }
 
@@ -552,11 +533,11 @@ pub fn LineType::list_marker(
   if start > last {
     return Nomatch
   }
-  match s.charcode_at(start).unsafe_to_char() {
+  match s[start].unsafe_to_char() {
     '-' | '+' | '*' as c => {
       let next = start + 1
       if next > last ||
-        (s.charcode_at(next).to_char() is Some(c) && @char.is_ascii_blank(c)) {
+        (s[next].to_char() is Some(c) && @char.is_ascii_blank(c)) {
         ListMarkerLine(Unordered(c), start)
       } else {
         Nomatch
@@ -568,7 +549,7 @@ pub fn LineType::list_marker(
         if k > last || count > 9 {
           return Nomatch
         }
-        break match s.charcode_at(k).unsafe_to_char() {
+        break match s[k].unsafe_to_char() {
           '0'..='9' as c =>
             continue s,
               last,
@@ -578,10 +559,7 @@ pub fn LineType::list_marker(
           '.' | ')' as c => {
             let next = k + 1
             if next > last ||
-              (
-                s.charcode_at(next).to_char() is Some(c) &&
-                @char.is_ascii_blank(c)
-              ) {
+              (s[next].to_char() is Some(c) && @char.is_ascii_blank(c)) {
               ListMarkerLine(Ordered(acc, c), k)
             } else {
               Nomatch
@@ -601,13 +579,13 @@ pub fn ext_task_marker(
   start~ : CharCodePos,
 ) -> (Char, CharCodePos)? {
   guard start < last else { None }
-  guard s.charcode_at(start) == '[' else { None }
+  guard s[start] == '[' else { None }
   let mut next = start + 1
   guard @char.at_checked(s, next) is Ok(u) else { None }
   next += @char.length_utf16(u.to_int())
-  guard next <= last && s.charcode_at(next) == ']' else { None }
+  guard next <= last && s[next] == ']' else { None }
   next += 1
   guard next <= last else { Some((u, last)) }
-  guard s.charcode_at(next) == ' ' else { None }
+  guard s[next] == ' ' else { None }
   Some((u, next))
 }

--- a/src/cmark_base/link.mbt
+++ b/src/cmark_base/link.mbt
@@ -13,14 +13,14 @@ pub fn link_destination(
   if start > last {
     return None
   }
-  if s.charcode_at(start) == '<' {
+  if s[start] == '<' {
     // delimited, i.e. start has '<'
     // https://spec.commonmark.org/current/#link-destination 1st
     for s = s, start = start, last = last, prev = '\u{0}', k = start + 1 {
       if k > last {
         break None
       }
-      let c = s.charcode_at(k).unsafe_to_char()
+      let c = s[k].unsafe_to_char()
       match (c, prev) {
         ('\n' | '\r', _) => break None
         ('\\', '\\') => continue s, start, last, '\u{0}', k + 1
@@ -39,7 +39,7 @@ pub fn link_destination(
       if k > last {
         break if bal == 0 { Some((false, start, k - 1)) } else { None }
       }
-      let c = s.charcode_at(k).unsafe_to_char()
+      let c = s[k].unsafe_to_char()
       match (c, prev) {
         ('\\', '\\') => continue s, start, last, '\u{0}', bal, k + 1
         ('(', '\\') => ()
@@ -82,7 +82,7 @@ pub fn[A] link_title(
   if start > line.last {
     return None
   }
-  match s.charcode_at(start).unsafe_to_char() {
+  match s[start].unsafe_to_char() {
     '"' | '\'' as char => {
       let spans = []
       accept_upto(char~, next_line~, s, lines, line~, spans, after=start).map(span_last => (
@@ -104,15 +104,15 @@ pub fn[A] link_title(
           continue next_line, s, lines, newline, prev_bslash, start, start
         }
         if not(prev_bslash) {
-          if s.charcode_at(k) == '(' {
+          if s[k] == '(' {
             break None
           }
-          if s.charcode_at(k) == ')' {
+          if s[k] == ')' {
             push_span(line~, start, k - 1, acc)
             break Some((line, acc, k))
           }
         }
-        let prev_bslash = s.charcode_at(k) == '\\' && not(prev_bslash)
+        let prev_bslash = s[k] == '\\' && not(prev_bslash)
         continue next_line, s, lines, line, prev_bslash, start, k + 1
       }
     }
@@ -133,7 +133,7 @@ pub fn[A] link_label(
   line~ : LineSpan,
   start~ : CharCodePos,
 ) -> (LineSpan, Array[Span], Last, String)? {
-  if start > line.last || s.charcode_at(start) != '[' {
+  if start > line.last || s[start] != '[' {
     return None
   }
   let start = start + 1
@@ -156,7 +156,7 @@ pub fn[A] link_label(
     if count > 999 {
       break None
     }
-    match (s.charcode_at(k).unsafe_to_char(), prev) {
+    match (s[k].unsafe_to_char(), prev) {
       ('\\', '\\') => {
         b.write_char('\\')
         let prev = '\u{0}'
@@ -181,13 +181,13 @@ pub fn[A] link_label(
     if @char.is_ascii_blank(prev) && not(b.is_empty()) {
       b.write_char(' ')
     }
-    let mut u = s.char_at(k)
+    let mut u = s.get_char(k).unwrap()
     if u == '\u{0}' {
       u = @char.rep
     }
     let k1 = k + @char.length_utf8(u.to_int())
     b.write_char(@char.to_ascii_lower(u))
-    let prev = s.charcode_at(k).unsafe_to_char()
+    let prev = s[k].unsafe_to_char()
     continue b, next_line, s, lines, line, prev, start, count + 1, k1
   }
 }

--- a/src/cmark_base/raw_html.mbt
+++ b/src/cmark_base/raw_html.mbt
@@ -3,7 +3,7 @@ fn tag_name(s : String, last~ : Int = -1, start~ : Int = 0) -> Int? {
   let last = if last < 0 { s.length() + last } else { last }
   for k = start + 1 {
     guard k <= last &&
-      s.charcode_at(k).to_char() is Some(c) &&
+      s[k].to_char() is Some(c) &&
       (@char.is_ascii_alphanum(c) || c == '-') else {
       break Some(k - 1)
     }
@@ -28,12 +28,11 @@ fn attribute_name(s : String, last~ : Int = -1, start~ : Int = 0) -> Next? {
     }
   }
 
-  if start > last ||
-    not(s.charcode_at(start).to_char() is Some(c) && char_is_start(c)) {
+  if start > last || not(s[start].to_char() is Some(c) && char_is_start(c)) {
     return None
   }
   for k = start + 1 {
-    if k > last || not(s.charcode_at(k).to_char() is Some(c) && char_is_cont(c)) {
+    if k > last || not(s[k].to_char() is Some(c) && char_is_cont(c)) {
       break Some(k - 1)
     }
     continue k + 1
@@ -52,7 +51,7 @@ fn[A] attribute_value(
   if start > line.last {
     return None
   }
-  let c = s.charcode_at(start).unsafe_to_char()
+  let c = s[start].unsafe_to_char()
   // https://spec.commonmark.org/current/#double-quoted-attribute-value
   // https://spec.commonmark.org/current/#unquoted-attribute-value
   if c is ('"' | '\'') {
@@ -64,7 +63,7 @@ fn[A] attribute_value(
   }
 
   for k = start + 1 {
-    if k <= line.last && s.charcode_at(k).to_char() is Some(c) && is_cont(c) {
+    if k <= line.last && s[k].to_char() is Some(c) && is_cont(c) {
       continue k + 1
     }
     let last = k - 1
@@ -93,7 +92,7 @@ fn[A] attribute(
     None
   }
   let nb = last_blank + 1
-  if s.charcode_at(nb) != '=' {
+  if s[nb] != '=' {
     return Some((line, end_name)) // No value
   }
   push_span(line=line1, nb, nb, spans.val)
@@ -141,14 +140,14 @@ fn[A] open_tag(
       break None
     }
     let next = last_blank + 1
-    break match s.charcode_at(next) {
+    break match s[next] {
       '>' => {
         push_span(line~, next, next, spans.val)
         Some((line, spans.val, next))
       }
       '/' => {
         let last = next + 1
-        if last > line.last || s.charcode_at(last) != '>' {
+        if last > line.last || s[last] != '>' {
           None
         } else {
           push_span(line~, next, last, spans.val)
@@ -190,7 +189,7 @@ fn[A] closing_tag(
     None
   }
   let last = last_blank + 1
-  if s.charcode_at(last) != '>' {
+  if s[last] != '>' {
     return None
   }
   push_span(line~, last, last, spans.val)
@@ -230,11 +229,11 @@ fn[A] processing_instruction(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.charcode_at(k) != '?' {
+    if s[k] != '?' {
       continue line, start, k + 1
     }
     let last = k + 1
-    if last <= line.last && s.charcode_at(last) == '>' { // ?>
+    if last <= line.last && s[last] == '>' { // ?>
       push_span(line~, start, last, acc)
       break Some((line, acc, last))
     }
@@ -252,15 +251,13 @@ fn[A] html_comment(
   start~ : CharCodePos,
 ) -> (LineSpan, Array[Span], CharCodePos)? {
   // Check we have at least <!-- and not <!--> or <!--->.
-  if start + 3 > line.last || s.charcode_at(start + 3) != '-' {
+  if start + 3 > line.last || s[start + 3] != '-' {
     return None
   }
-  if start + 4 <= line.last && s.charcode_at(start + 4) == '>' {
+  if start + 4 <= line.last && s[start + 4] == '>' {
     return None
   }
-  if start + 5 <= line.last &&
-    s.charcode_at(start + 4) == '-' &&
-    s.charcode_at(start + 5) == '>' {
+  if start + 5 <= line.last && s[start + 4] == '-' && s[start + 5] == '>' {
     return None
   }
   let acc = []
@@ -271,10 +268,10 @@ fn[A] html_comment(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.charcode_at(k) == '-' && s.charcode_at(k - 1) != '-' {
+    if s[k] == '-' && s[k - 1] != '-' {
       let last = k + 2
-      if last <= line.last && s.charcode_at(k + 1) == '-' {
-        break if s.charcode_at(last) == '>' { // And we do not end with -
+      if last <= line.last && s[k + 1] == '-' {
+        break if s[last] == '>' { // And we do not end with -
           push_span(line~, start, last, acc)
           Some((line, acc, last))
         } else {
@@ -309,13 +306,11 @@ fn[A] cdata_section(
       let start = first_non_blank_in_span(s, new_line)
       continue new_line, start, start
     }
-    if s.charcode_at(k) != ']' {
+    if s[k] != ']' {
       continue line, start, k + 1
     }
     let last = k + 2
-    if last <= line.last &&
-      s.charcode_at(k + 1) == ']' &&
-      s.charcode_at(last) == '>' { // ]>
+    if last <= line.last && s[k + 1] == ']' && s[last] == '>' { // ]>
       push_span(line~, start, last, acc)
       break Some((line, acc, last))
     }
@@ -333,14 +328,14 @@ pub fn[A] raw_html(
 ) -> (LineSpan, Array[Span], CharCodePos)? {
   let next = start + 1
   let { last, .. } = line
-  guard next <= last && s.charcode_at(start) == '<' else { None }
-  match s.charcode_at(next) {
+  guard next <= last && s[start] == '<' else { None }
+  match s[next] {
     '/' => closing_tag(next_line~, s, lines, line~, start~)
     '?' => processing_instruction(next_line, s, lines, line~, start~)
     '!' => {
       let next = next + 1
       guard next <= last else { None }
-      match s.charcode_at(next).unsafe_to_char() {
+      match s[next].unsafe_to_char() {
         '-' => html_comment(next_line~, s, lines, line~, start~)
         '[' => cdata_section(next_line~, s, lines, line~, start~)
         c => {

--- a/src/cmark_base/runs.mbt
+++ b/src/cmark_base/runs.mbt
@@ -6,7 +6,7 @@ pub fn run_of(
   last~ : CharCodePos,
   start~ : CharCodePos,
 ) -> Last {
-  if start > last || s.charcode_at(start).unsafe_to_char() != char {
+  if start > last || s[start].unsafe_to_char() != char {
     return start - 1
   }
   run_of(char~, s, last~, start=start + 1)
@@ -20,9 +20,7 @@ pub fn first_non_blank(
   start~ : CharCodePos,
 ) -> CharCodePos {
   for k in start..=last {
-    guard s.charcode_at(k).to_char() is Some(c) && @char.is_ascii_blank(c) else {
-      return k
-    }
+    guard s[k].to_char() is Some(c) && @char.is_ascii_blank(c) else { return k }
   }
   last + 1
 }
@@ -42,7 +40,7 @@ pub fn last_non_blank(
   if start < first {
     return first - 1
   }
-  match s.charcode_at(start) {
+  match s[start] {
     ' ' | '\t' => last_non_blank(s, first~, start=start - 1)
     _ => start
   }
@@ -58,7 +56,7 @@ pub fn rev_drop_spaces(
   if start < first {
     return first - 1
   }
-  match s.charcode_at(start) {
+  match s[start] {
     ' ' => rev_drop_spaces(s, first~, start=start - 1)
     _ => start
   }
@@ -103,7 +101,7 @@ fn[A] accept_to(
       let start = first_non_blank_in_span(s, new_line)
       continue lines, new_line, start, start
     }
-    if s.charcode_at(k).unsafe_to_char() == char {
+    if s[k].unsafe_to_char() == char {
       push_span(line~, start, k, spans)
       break Some((line, k))
     }
@@ -133,11 +131,11 @@ fn[A] accept_upto(
       let prev_bslash = false
       continue char, next_line, s, lines, newline, prev_bslash, start, acc, start
     } else {
-      if s.charcode_at(k) == char.to_int() && not(prev_bslash) {
+      if s[k] == char.to_int() && not(prev_bslash) {
         push_span(line~, start, k - 1, acc)
         break Some((line, k))
       }
-      let prev_bslash = s.charcode_at(k) == '\\' && not(prev_bslash)
+      let prev_bslash = s[k] == '\\' && not(prev_bslash)
       continue char, next_line, s, lines, line, prev_bslash, start, acc, k + 1
     }
   }
@@ -198,11 +196,7 @@ pub fn first_non_escaped_char(
   start~ : CharCodePos,
 ) -> CharCodePos {
   for k = start; ; k = k + 1 {
-    if k > last ||
-      (
-        s.charcode_at(k) == c.to_int() &&
-        (k == start || s.charcode_at(k - 1) != '\\')
-      ) {
+    if k > last || (s[k] == c.to_int() && (k == start || s[k - 1] != '\\')) {
       break k
     }
   }

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -178,7 +178,7 @@ fn buffer_add_html_escaped_string(b : Buffer, s : String) -> Unit {
       break
     }
     let next = i + 1
-    match s.charcode_at(i) {
+    match s[i] {
       '\u{0}' => {
         flush(b, start, i)
         b.write_char(@char.rep)
@@ -260,7 +260,7 @@ fn buffer_add_pct_encoded_string(b : Buffer, s : String) -> Unit { // Percent en
       break
     }
     let next = i + 1
-    match s.charcode_at(i) {
+    match s[i] {
       c if c.to_char() is Some(c) && (@char.is_ascii_alphanum(c) || is_delim(c)) =>
         continue b, s, max, start, next
       '&' => {
@@ -554,7 +554,7 @@ fn code_block(c : Context, cb : @cmark.CodeBlock) -> Unit {
     c.b.write_char('\n')
   }
   if lang is Some((lang, _env)) {
-    if backend_blocks(c) && lang.charcode_at(0) == '=' {
+    if backend_blocks(c) && lang[0] == '=' {
       if lang == "=html" && not(safe(c)) {
         block_lines(c, cb.code.to_array())
       }


### PR DESCRIPTION
> [!NOTE]
> This PR was made by an LLM agent.

This PR addresses all deprecation warnings in the codebase:

1. Replaced deprecated `charcode_at()` method with direct string indexing `s[i]`
2. Replaced deprecated `char_at()` method with `s.get_char(i).unwrap()`
3. Replaced deprecated `@math.minimum`/`@math.maximum` with `@cmp.minimum`/`@cmp.maximum`
4. Replaced deprecated `.or()` method with `.unwrap_or()`
5. Replaced deprecated `.or_else()` method with `.unwrap_or_else()`

All 370 tests pass successfully after these changes, ensuring no functionality was broken.