### PR TITLE
Fix UTF-16 char helpers

### DIFF
--- a/src/char/text.mbt
+++ b/src/char/text.mbt
@@ -1,27 +1,18 @@
 ///|
+fn code_point_of_surrogate_pair(leading : UInt16, trailing : UInt16) -> Char {
+  ((leading.to_int() - 0xD800) * 0x400 + trailing.to_int() - 0xDC00 + 0x10000).unsafe_to_char()
+}
+
+///|
 pub fn at_checked(s : StringView, idx : Int) -> Result[Char, Int] {
-  let min_leading_surrogate : UInt16 = 0xD800
-  let max_leading_surrogate : UInt16 = 0xDBFF
-  let min_trailing_surrogate : UInt16 = 0xDC00
-  let max_trailing_surrogate : UInt16 = 0xDFFF
-  fn is_leading_surrogate(c : UInt16) -> Bool {
-    min_leading_surrogate <= c && c <= max_leading_surrogate
-  }
-
-  fn is_trailing_surrogate(c : UInt16) -> Bool {
-    min_trailing_surrogate <= c && c <= max_trailing_surrogate
-  }
-
-  fn code_point_of_surrogate_pair(leading : UInt16, trailing : UInt16) -> Char {
-    ((leading.to_int() - 0xD800) * 0x400 + trailing.to_int() - 0xDC00 + 0x10000).unsafe_to_char()
-  }
-
+  guard 0 <= idx && idx < s.length() else { Err(0) }
   let c1 = s[idx]
-  if is_leading_surrogate(c1) {
-    guard idx + 1 < s.length() else { Err(c1.to_int()) }
-    let c2 = s[idx + 1]
-    Ok(code_point_of_surrogate_pair(c1, c2))
-  } else if is_trailing_surrogate(c1) {
+  if c1.is_leading_surrogate() {
+    guard idx + 1 < s.length() && s[idx + 1].is_trailing_surrogate() else {
+      Err(c1.to_int())
+    }
+    Ok(code_point_of_surrogate_pair(c1, s[idx + 1]))
+  } else if c1.is_trailing_surrogate() {
     Err(c1.to_int())
   } else {
     Ok(c1.unsafe_to_char())
@@ -56,20 +47,31 @@ pub fn sub_includes(
 /// surrogate (0xDC00–0xDFFF), the character is a surrogate pair starting at
 /// `before - 2`; otherwise the character starts at `before - 1`.
 pub fn prev_char(s : StringView, first~ : Int, before~ : Int) -> Char {
-  guard first < before else { ' ' }
-  let idx = before - 1
-  // UTF-16 trailing surrogate range: 0xDC00 .. 0xDFFF
-  if s[idx] >= 0xDC00 && s[idx] <= 0xDFFF && idx > first {
-    s.get_char(idx - 1).unwrap()
+  guard 0 <= first && first < before && before <= s.length() else { ' ' }
+  let k = before - 1
+  let u = s[k]
+  if u.is_trailing_surrogate() {
+    if k > first && s[k - 1].is_leading_surrogate() {
+      code_point_of_surrogate_pair(s[k - 1], u)
+    } else {
+      rep
+    }
   } else {
-    s.get_char(idx).unwrap()
+    match u.to_char() {
+      Some(c) => c
+      // Lone leading surrogate.
+      None => rep
+    }
   }
 }
 
 ///|
 pub fn next_char(s : StringView, last~ : Int, after~ : Int) -> Char {
-  guard after < last else { ' ' }
-  s.get_char(after + 1).unwrap()
+  guard after < last && after + 1 < s.length() else { ' ' }
+  match at_checked(s, after + 1) {
+    Ok(c) => c
+    Err(_) => rep
+  }
 }
 
 ///|
@@ -86,62 +88,57 @@ pub fn utf_16_clean_raw(
     }
   }
 
-  fn clean(last, first, dirty) {
-    let flush = fn(last, start, k) {
-      if start <= last {
-        buf.write_view(s[start:k])
-      }
-    }
-    flush(last, first, dirty)
-    for start = dirty, k = dirty {
-      if k > last {
-        flush(last, start, k)
-        break buf.to_string()
-      }
-      if s[k] == '\u{0}' {
-        let next = k + 1
-        flush(last, start, k)
+  // Writes [first;last] to [buf], replacing U+0000, unpaired surrogates
+  // and characters whose surrogate pair is cut by the span with U+FFFD.
+  // Never creates string views: a view boundary that lands on an
+  // unpaired surrogate aborts.
+  fn clean(last, first) {
+    for k = first {
+      guard k <= last else { break buf.to_string() }
+      let u = s[k]
+      if u == '\u{0}' {
         buf.write_char(rep)
-        continue next, next
+        continue k + 1
       }
-      if s[k].to_char() is Some(c) && c.is_ascii() {
-        continue start, k + 1
-      }
-      match at_checked(s, k) {
-        Ok(d) => {
-          let next = k + length_utf16(d.to_int())
-          continue start, next
+      match u.to_char() {
+        Some(c) => {
+          buf.write_char(c)
+          continue k + 1
         }
-        Err(d) => {
-          let next = k + length_utf16(d)
-          flush(last, start, k)
-          buf.write_char(rep)
-          continue next, next
-        }
+        None =>
+          match at_checked(s, k) {
+            Ok(d) if k + 1 <= last => {
+              buf.write_char(d)
+              continue k + length_utf16(d.to_int())
+            }
+            // Unpaired surrogate, or a pair whose trailing half
+            // lies beyond [last].
+            _ => {
+              buf.write_char(rep)
+              continue k + 1
+            }
+          }
       }
     }
   }
 
-  fn check(last, first, k) {
-    for k = k {
-      break if k > last {
-        s[first:last + 1].to_owned()
-      } else if s[k] == '\u{0}' {
-        buf.reset()
-        clean(last, first, k)
-      } else if s[k].to_char() is Some(c) && c.is_ascii() {
-        continue k + 1
-      } else {
-        match at_checked(s, k) {
-          Ok(d) => {
-            let next = k + length_utf16(d.to_int())
-            continue next
+  // Whether [first;last] can be returned as a plain substring copy.
+  fn is_clean(last, first) {
+    for k = first {
+      guard k <= last else {
+        // The view boundary at last + 1 must not land on the trailing
+        // half of a surrogate pair.
+        break last + 1 >= s.length() || !s[last + 1].is_trailing_surrogate()
+      }
+      let u = s[k]
+      guard u != '\u{0}' else { break false }
+      match u.to_char() {
+        Some(_) => continue k + 1
+        None =>
+          match at_checked(s, k) {
+            Ok(d) if k + 1 <= last => continue k + length_utf16(d.to_int())
+            _ => break false
           }
-          Err(_d) => {
-            buf.reset()
-            clean(last, first, k)
-          }
-        }
       }
     }
   }
@@ -157,12 +154,12 @@ pub fn utf_16_clean_raw(
   let max = s.length() - 1
   let last = @cmp.minimum(last, max)
   let first = @cmp.maximum(first, 0)
-  if pad == 0 {
-    return check(last, first, first)
+  if pad == 0 && is_clean(last, first) {
+    return s[first:last + 1].to_owned()
   }
   buf.reset()
   pad_it()
-  clean(last, first, first)
+  clean(last, first)
 }
 
 ///|
@@ -194,7 +191,19 @@ fn flush(
   k : Int,
 ) -> Unit {
   if start <= last {
-    buf.write_view(s[start:k])
+    for j = start {
+      guard j < k else { break }
+      match at_checked(s, j) {
+        Ok(c) => {
+          buf.write_char(c)
+          continue j + length_utf16(c.to_int())
+        }
+        Err(_) => {
+          buf.write_char(rep)
+          continue j + 1
+        }
+      }
+    }
   }
 }
 
@@ -351,15 +360,17 @@ fn _utf_16_clean_unesc_unref(
             continue start, next
           }
           match at_checked(s, k) {
-            Ok(d) => {
+            Ok(d) if k + length_utf16(d.to_int()) - 1 <= last => {
               let next = k + length_utf16(d.to_int())
               continue start, next
             }
-            Err(d) => {
-              let next = k + length_utf16(d)
+            // Unpaired surrogate, or a valid pair whose trailing half
+            // lies beyond [last]: emit U+FFFD and keep the span
+            // boundary, matching `utf_16_clean_raw`.
+            _ => {
               flush(last, start, k)
               buf.write_char(rep)
-              continue next, next
+              continue k + 1, k + 1
             }
           }
         }
@@ -372,7 +383,15 @@ fn _utf_16_clean_unesc_unref(
   let last = @cmp.minimum(last, max)
   let first = @cmp.maximum(first, 0)
   for k = first {
-    guard k <= last else { break s[first:last + 1].to_owned() }
+    guard k <= last else {
+      // The view boundary at last + 1 must not land on the trailing
+      // half of a surrogate pair.
+      if last + 1 < s.length() && s[last + 1].is_trailing_surrogate() {
+        buf.reset()
+        break resolve(last, first, last + 1)
+      }
+      break s[first:last + 1].to_owned()
+    }
     match (s[k], do_unesc) {
       ('\\', true) | ('&', _) | ('\u{0}', _) => {
         buf.reset()
@@ -383,11 +402,12 @@ fn _utf_16_clean_unesc_unref(
           continue k + 1
         }
         match at_checked(s, k) {
-          Ok(d) => {
+          Ok(d) if k + length_utf16(d.to_int()) - 1 <= last => {
             let next = k + length_utf16(d.to_int())
             continue next
           }
-          Err(_d) => {
+          // Unpaired surrogate, or a pair cut by the end of the span.
+          _ => {
             buf.reset()
             break resolve(last, first, k)
           }

--- a/src/char/text_test.mbt
+++ b/src/char/text_test.mbt
@@ -517,3 +517,88 @@ test "sub_includes repeated pattern match" {
     content="true",
   )
 }
+
+///|
+fn string_of_code_units(units : Array[Int]) -> String {
+  let b = StringBuilder::new()
+  for u in units {
+    b.write_char(u.unsafe_to_char())
+  }
+  b.to_string()
+}
+
+///|
+test "prev_char returns the immediately preceding char" {
+  // BMP chars are single UTF-16 units: the old implementation scanned
+  // backwards for UTF-8 lead bytes and returned the wrong char.
+  inspect(@char.prev_char("aж*", first=0, before=2), content="ж")
+  inspect(@char.prev_char("a😀*", first=0, before=3), content="😀")
+  inspect(@char.prev_char("ab", first=0, before=1), content="a")
+  inspect(@char.prev_char("ab", first=1, before=1), content=" ")
+}
+
+///|
+test "prev_char and next_char on unpaired surrogates" {
+  let lone_trail = string_of_code_units(['a'.to_int(), 0xDC00, '*'.to_int()])
+  inspect(@char.prev_char(lone_trail, first=0, before=2), content="�")
+  inspect(@char.next_char(lone_trail, last=2, after=0), content="�")
+  let lone_lead = string_of_code_units(['a'.to_int(), 0xD800, '*'.to_int()])
+  inspect(@char.prev_char(lone_lead, first=0, before=2), content="�")
+  inspect(@char.next_char(lone_lead, last=2, after=0), content="�")
+}
+
+///|
+test "prev_char and next_char out-of-range arguments" {
+  inspect(@char.prev_char("ab", first=0, before=99), content=" ")
+  inspect(@char.prev_char("ab", first=-5, before=0), content=" ")
+  inspect(@char.next_char("ab", last=99, after=10), content=" ")
+}
+
+///|
+test "at_checked out of bounds and unpaired surrogates" {
+  debug_inspect(@char.at_checked("a", 5), content="Err(0)")
+  debug_inspect(@char.at_checked("a", -1), content="Err(0)")
+  // A leading surrogate must be followed by a trailing surrogate.
+  let lead_then_ascii = string_of_code_units([0xD800, 'a'.to_int()])
+  debug_inspect(@char.at_checked(lead_then_ascii, 0), content="Err(55296)")
+}
+
+///|
+test "utf_16_clean_raw with unpaired surrogates" {
+  let buf = StringBuilder::new()
+  let lone = string_of_code_units([0xDC00])
+  inspect(@char.utf_16_clean_raw(buf, lone, first=0, last=0), content="�")
+  let mixed = string_of_code_units(['a'.to_int(), 0xDC00, 'b'.to_int()])
+  inspect(@char.utf_16_clean_raw(buf, mixed, first=0, last=2), content="a�b")
+  // A span that cuts a surrogate pair in half.
+  let emoji = "😀"
+  inspect(@char.utf_16_clean_raw(buf, emoji, first=0, last=0), content="�")
+  // A clean span followed by an unpaired trailing surrogate: the span
+  // boundary must not abort.
+  let clean_then_trail = string_of_code_units(['a'.to_int(), 0xDC00])
+  inspect(
+    @char.utf_16_clean_raw(buf, clean_then_trail, first=0, last=0),
+    content="a",
+  )
+}
+
+///|
+test "utf_16_clean_unref preserves the span boundary on a cut pair" {
+  let buf = StringBuilder::new()
+  // The span [0,0] ends on the leading half of "😀"; the trailing unit
+  // is outside the span and must not leak into the output (it becomes
+  // U+FFFD, matching utf_16_clean_raw).
+  inspect(@char.utf_16_clean_unref(buf, "😀", first=0, last=0), content="�")
+  inspect(
+    @char.utf_16_clean_unesc_unref(buf, "😀", first=0, last=0),
+    content="�",
+  )
+  // The full pair within the span is preserved.
+  inspect(
+    @char.utf_16_clean_unref(buf, "😀", first=0, last=1),
+    content="😀",
+  )
+  // A lone trailing surrogate also becomes U+FFFD.
+  let lone = string_of_code_units(['a'.to_int(), 0xDC00])
+  inspect(@char.utf_16_clean_unref(buf, lone, first=0, last=1), content="a�")
+}


### PR DESCRIPTION
## Summary

- Make `@char.at_checked` bounds-safe and require valid surrogate pairs
- Harden `prev_char` and `next_char` for UTF-16 bounds and unpaired surrogates, building on the normal-case `prev_char` fix already merged in #141
- Use core `UInt16::{is_leading_surrogate,is_trailing_surrogate}` helpers instead of local surrogate-range predicates
- Make `utf_16_clean_raw`, `utf_16_clean_unref`, and `utf_16_clean_unesc_unref` safe when spans contain or cut surrogate pairs

## Rebase notes

Rebased onto the current `main`, including #141, #146, #129, and #133. The README correction and `prev_char` documentation from #141 are kept; the remaining `prev_char` diff adds the bounds and malformed-surrogate handling covered by this PR's regression tests.

## Scope

This is the foundational char-only slice extracted from #127. It intentionally does not change parser or renderer code; follow-up PRs can use these primitives without re-reviewing the UTF-16 helper changes.

No new public API is added; `pkg.generated.mbti` is unchanged relative to `main`.

## Validation

- `moon test src/char --target wasm-gc` — 83/83 passed
- `moon check --warn-list +73` — 0 errors
- `moon test` — 379/379 passed
- `moon info` — generated interfaces unchanged
- `moon fmt`
