### PR TITLE
Fix UTF-16 scanner indexing

### DIFF
--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -197,15 +197,18 @@ pub fn CodeBlock::make_fence(self : CodeBlock) -> (Char, Count) {
 pub fn CodeBlock::language_of_info_string(s : String) -> (String, String)? {
   guard !s.is_empty() else { None }
   let max = s.length() - 1
+  // ASCII whitespace is a single code unit, so scan code units: indexing
+  // chars with `get_char` aborts on the trailing half of a surrogate pair.
   let white = for i = 0; ; i = i + 1 {
-    if i > max || @char.is_ascii_whitespace(s.get_char(i).unwrap()) {
+    if i > max || (s[i].to_char() is Some(c) && @char.is_ascii_whitespace(c)) {
       break i
     }
   }
   let rem_first = @cmark_base.first_non_blank(s, last=max, start=white)
-  let lang = s[0:white].to_owned()
+  let buf = StringBuilder::new()
+  let lang = @char.utf_16_clean_raw(buf, s, first=0, last=white - 1)
   guard !lang.is_empty() else { None }
-  Some((lang, s[rem_first:max + 1].to_owned()))
+  Some((lang, @char.utf_16_clean_raw(buf, s, first=rem_first, last=max)))
 }
 
 ///|

--- a/src/cmark_base/autolink.mbt
+++ b/src/cmark_base/autolink.mbt
@@ -53,14 +53,19 @@ pub fn autolink_uri(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
   let char_is_scheme = fn(c) {
     @char.is_ascii_alphanum(c) || c is ('+' | '-' | '.')
   }
-  let char_is_uri = fn(c : Char) {
-    !(c is ('\u{0}'..='\u{1f}' | '\u{7f}' | '<' | '>' | ' '))
+  // Code units outside the excluded ASCII set are URI chars; surrogate
+  // halves belong to non-ASCII chars, which are allowed.
+  let unit_is_uri = fn(u : UInt16) {
+    match u.to_char() {
+      Some(c) => !(c is ('\u{0}'..='\u{1f}' | '\u{7f}' | '<' | '>' | ' '))
+      None => true
+    }
   }
   let rest = fn(s : String, last, k) {
     for k in k..<=last {
-      let sk = s.get_char(k).unwrap()
-      guard !char_is_uri(sk) else { continue }
-      break if sk == '>' { Some(k) } else { None }
+      let u = s[k]
+      guard !unit_is_uri(u) else { continue }
+      break if u == '>' { Some(k) } else { None }
     } nobreak {
       None
     }
@@ -68,12 +73,13 @@ pub fn autolink_uri(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
   let next = start + 1
   guard next <= last &&
     s[start] == '<' &&
-    s.get_char(next).unwrap().is_ascii_alphabetic() else {
+    s[next].to_char() is Some(first_scheme_char) &&
+    first_scheme_char.is_ascii_alphabetic() else {
     return None
   }
   for c = 1, k = next + 1 {
     guard k <= last else { break None }
-    let sk = s.get_char(k).unwrap()
+    guard s[k].to_char() is Some(sk) else { break None }
     if char_is_scheme(sk) && c <= 32 {
       continue c + 1, k + 1
     }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -398,7 +398,16 @@ pub fn LineType::html_block_start(
         }
         continue i + 1
       }
-      let tag = s[tag_first:tag_last + 1].to_owned().to_lower()
+      // The tag name is ASCII alphabetic: build it from code units. A
+      // view boundary at tag_last + 1 could land on an unpaired
+      // surrogate and abort.
+      let tag = {
+        let b = StringBuilder::new(size_hint=tag_last - tag_first + 1)
+        for i in tag_first..<=tag_last {
+          b.write_char(@char.to_ascii_lower(s[i].unsafe_to_char()))
+        }
+        b.to_string()
+      }
       let is_open_end = {
         let n = tag_last + 1
         n > last ||
@@ -409,7 +418,11 @@ pub fn LineType::html_block_start(
         | 62)
       }
       let is_open_close_end = is_open_end ||
-        (tag_last + 2 <= last && s[tag_last + 1:tag_last + 3] == "/>")
+        (
+          tag_last + 2 <= last &&
+          s[tag_last + 1] == '/' &&
+          s[tag_last + 2] == '>'
+        )
       if c != '/' {
         if html_start_cond_1_set.contains(tag) && is_open_end {
           HtmlBlockLine(EndCond1) // 1
@@ -439,19 +452,18 @@ fn LineType::html_block_end_cond_1(
     guard k + 3 <= last else { break false }
     guard s[k] == '<' && s[k + 1] == '/' else { continue k + 1 }
     let next = k + 2
-    let is_end_tag = {
-      let lower_s_sub = lower_s[next:]
-      match s[next] {
-        'p' => lower_s_sub.has_prefix("pre>")
-        's' =>
-          if s[k + 3] == 't' {
-            lower_s_sub.has_prefix("style>")
-          } else {
-            lower_s_sub.has_prefix("script>")
-          }
-        't' => lower_s_sub.has_prefix("textarea>")
-        _ => false
-      }
+    // Only create the view once the unit at `next` is a known ASCII
+    // char: a view boundary on an unpaired surrogate aborts.
+    let is_end_tag = match s[next] {
+      'p' => lower_s[next:].has_prefix("pre>")
+      's' =>
+        if s[k + 3] == 't' {
+          lower_s[next:].has_prefix("style>")
+        } else {
+          lower_s[next:].has_prefix("script>")
+        }
+      't' => lower_s[next:].has_prefix("textarea>")
+      _ => false
     }
     guard !is_end_tag else { break true }
     continue k + 1

--- a/src/cmark_base/link.mbt
+++ b/src/cmark_base/link.mbt
@@ -182,13 +182,17 @@ pub fn[A] link_label(
     if @char.is_ascii_blank(prev) && !b.is_empty() {
       b.write_char(' ')
     }
-    let mut u = s.get_char(k).unwrap()
+    // Indices are UTF-16 code units, so advance by the char's UTF-16
+    // length; unpaired surrogates normalize to U+FFFD.
+    let mut u = match @char.at_checked(s, k) {
+      Ok(c) => c
+      Err(_) => @char.rep
+    }
     if u == '\u{0}' {
       u = @char.rep
     }
-    let k1 = k + @char.length_utf8(u.to_int())
+    let k1 = k + @char.length_utf16(u.to_int())
     b.write_char(@char.to_ascii_lower(u))
-    let prev = s[k].unsafe_to_char()
-    continue line, prev, start, count + 1, k1
+    continue line, u, start, count + 1, k1
   }
 }

--- a/src/cmark_html/utf16_regression_test.mbt
+++ b/src/cmark_html/utf16_regression_test.mbt
@@ -1,0 +1,43 @@
+// Regression tests for valid non-BMP Unicode at UTF-16 boundaries.
+
+///|
+/// `language_of_info_string` must scan by UTF-16 code units, not use a
+/// code-unit index as a character index.
+test "astral char in fence info string" {
+  inspect(
+    @cmark_html.render("```😀\nx\n```"),
+    content="<pre><code class=\"language-😀\">x\n</code></pre>\n",
+  )
+  inspect(
+    @cmark_html.render("```a😀 b\nx\n```"),
+    content="<pre><code class=\"language-a😀\">x\n</code></pre>\n",
+  )
+}
+
+///|
+/// `autolink_uri` used to step one UTF-16 code unit at a time with
+/// `get_char`, landing on the trailing half of a surrogate pair.
+test "astral char in autolink" {
+  inspect(
+    @cmark_html.render("<http://a😀>"),
+    content="<p><a href=\"http://a%F0%9F%98%80\">http://a😀</a></p>\n",
+  )
+}
+
+///|
+/// Link label normalization must advance by UTF-16 length, not UTF-8
+/// byte length.
+test "astral char in link label" {
+  inspect(
+    @cmark_html.render("[😀]: /x\n\n[😀]"),
+    content="<p><a href=\"/x\">😀</a></p>\n",
+  )
+}
+
+///|
+/// HTML block start detection must avoid slices whose boundaries can land
+/// inside a surrogate pair.
+test "astral char after html tag name" {
+  inspect(@cmark_html.render("<d.😀"), content="<p>&lt;d.😀</p>\n")
+  inspect(@cmark_html.render("<div😀>"), content="<p>&lt;div😀&gt;</p>\n")
+}


### PR DESCRIPTION
## Summary

- Fix code fence info-string language parsing for astral characters
- Make URI autolink scanning operate on UTF-16 code units without unwrapping surrogate halves
- Advance link-label normalization by UTF-16 length instead of UTF-8 byte length
- Avoid HTML block detection slices whose boundaries can land inside surrogate pairs
- Add black-box render regressions for valid non-BMP Unicode in fence info, autolinks, link labels, and HTML tag probes

## Scope

This is the valid-Unicode scanner/indexing slice extracted from #127. Its prerequisite char-helper and HTML-renderer fixes have been merged in #132 and #134.

Rebased onto `main` at `52ef585`, replaying only the scanner/indexing commit and dropping the old #132/#134 commits from this branch's unique history. The scanner patch is unchanged according to `git range-diff`; the final diff contains four implementation files and one black-box regression test file.

No public API changes. This PR does not introduce malformed-input sanitization or an input assertion policy; parser-boundary handling remains separate in #136.

## Validation

- `moon test src/cmark_html --target wasm-gc` — 33/33 passed
- `moon check --warn-list +73` — 0 errors; deprecation warnings remain
- `moon test --target wasm-gc` — 386/386 passed
- `moon test --target wasm` — 386/386 passed
- `moon test --target js` — 386/386 passed
- `moon test --target native` — 389/389 passed
- `moon info` and `moon fmt` — no generated-interface or formatting changes
- `git diff --check origin/main...HEAD`
