### PR TITLE
Assert parser UTF-16 input invariant

### DIFF
--- a/src/char/README.mbt.md
+++ b/src/char/README.mbt.md
@@ -61,7 +61,7 @@ test "string navigation" {
   inspect(@char.next_char(s, last=0, after=7), content=" ")
 
   // Navigate to previous character
-  inspect(@char.prev_char(s, first=7, before=9), content="世")
+  inspect(@char.prev_char(s, first=7, before=9), content="界")
 }
 ```
 

--- a/src/char/text.mbt
+++ b/src/char/text.mbt
@@ -1,27 +1,18 @@
 ///|
+fn code_point_of_surrogate_pair(leading : UInt16, trailing : UInt16) -> Char {
+  ((leading.to_int() - 0xD800) * 0x400 + trailing.to_int() - 0xDC00 + 0x10000).unsafe_to_char()
+}
+
+///|
 pub fn at_checked(s : StringView, idx : Int) -> Result[Char, Int] {
-  let min_leading_surrogate : UInt16 = 0xD800
-  let max_leading_surrogate : UInt16 = 0xDBFF
-  let min_trailing_surrogate : UInt16 = 0xDC00
-  let max_trailing_surrogate : UInt16 = 0xDFFF
-  fn is_leading_surrogate(c : UInt16) -> Bool {
-    min_leading_surrogate <= c && c <= max_leading_surrogate
-  }
-
-  fn is_trailing_surrogate(c : UInt16) -> Bool {
-    min_trailing_surrogate <= c && c <= max_trailing_surrogate
-  }
-
-  fn code_point_of_surrogate_pair(leading : UInt16, trailing : UInt16) -> Char {
-    ((leading.to_int() - 0xD800) * 0x400 + trailing.to_int() - 0xDC00 + 0x10000).unsafe_to_char()
-  }
-
+  guard 0 <= idx && idx < s.length() else { Err(0) }
   let c1 = s[idx]
-  if is_leading_surrogate(c1) {
-    guard idx + 1 < s.length() else { Err(c1.to_int()) }
-    let c2 = s[idx + 1]
-    Ok(code_point_of_surrogate_pair(c1, c2))
-  } else if is_trailing_surrogate(c1) {
+  if c1.is_leading_surrogate() {
+    guard idx + 1 < s.length() && s[idx + 1].is_trailing_surrogate() else {
+      Err(c1.to_int())
+    }
+    Ok(code_point_of_surrogate_pair(c1, s[idx + 1]))
+  } else if c1.is_trailing_surrogate() {
     Err(c1.to_int())
   } else {
     Ok(c1.unsafe_to_char())
@@ -52,24 +43,31 @@ pub fn sub_includes(
 
 ///|
 pub fn prev_char(s : StringView, first~ : Int, before~ : Int) -> Char {
-  guard first < before else { ' ' }
-  let k = for start = before - 1; ; start = start - 1 {
-    guard first <= start else { break first }
-    if s[start]
-      is ('\u{0}'..='\u{7f}'
-      | '\u{c2}'..='\u{df}'
-      | '\u{e0}'..='\u{ef}'
-      | '\u{f0}'..='\u{f4}') {
-      break start
+  guard 0 <= first && first < before && before <= s.length() else { ' ' }
+  let k = before - 1
+  let u = s[k]
+  if u.is_trailing_surrogate() {
+    if k > first && s[k - 1].is_leading_surrogate() {
+      code_point_of_surrogate_pair(s[k - 1], u)
+    } else {
+      rep
+    }
+  } else {
+    match u.to_char() {
+      Some(c) => c
+      // Lone leading surrogate.
+      None => rep
     }
   }
-  s.get_char(k).unwrap()
 }
 
 ///|
 pub fn next_char(s : StringView, last~ : Int, after~ : Int) -> Char {
-  guard after < last else { ' ' }
-  s.get_char(after + 1).unwrap()
+  guard after < last && after + 1 < s.length() else { ' ' }
+  match at_checked(s, after + 1) {
+    Ok(c) => c
+    Err(_) => rep
+  }
 }
 
 ///|
@@ -86,62 +84,57 @@ pub fn utf_16_clean_raw(
     }
   }
 
-  fn clean(last, first, dirty) {
-    let flush = fn(last, start, k) {
-      if start <= last {
-        buf.write_view(s[start:k])
-      }
-    }
-    flush(last, first, dirty)
-    for start = dirty, k = dirty {
-      if k > last {
-        flush(last, start, k)
-        break buf.to_string()
-      }
-      if s[k] == '\u{0}' {
-        let next = k + 1
-        flush(last, start, k)
+  // Writes [first;last] to [buf], replacing U+0000, unpaired surrogates
+  // and characters whose surrogate pair is cut by the span with U+FFFD.
+  // Never creates string views: a view boundary that lands on an
+  // unpaired surrogate aborts.
+  fn clean(last, first) {
+    for k = first {
+      guard k <= last else { break buf.to_string() }
+      let u = s[k]
+      if u == '\u{0}' {
         buf.write_char(rep)
-        continue next, next
+        continue k + 1
       }
-      if s[k].to_char() is Some(c) && c.is_ascii() {
-        continue start, k + 1
-      }
-      match at_checked(s, k) {
-        Ok(d) => {
-          let next = k + length_utf16(d.to_int())
-          continue start, next
+      match u.to_char() {
+        Some(c) => {
+          buf.write_char(c)
+          continue k + 1
         }
-        Err(d) => {
-          let next = k + length_utf16(d)
-          flush(last, start, k)
-          buf.write_char(rep)
-          continue next, next
-        }
+        None =>
+          match at_checked(s, k) {
+            Ok(d) if k + 1 <= last => {
+              buf.write_char(d)
+              continue k + length_utf16(d.to_int())
+            }
+            // Unpaired surrogate, or a pair whose trailing half
+            // lies beyond [last].
+            _ => {
+              buf.write_char(rep)
+              continue k + 1
+            }
+          }
       }
     }
   }
 
-  fn check(last, first, k) {
-    for k = k {
-      break if k > last {
-        s[first:last + 1].to_owned()
-      } else if s[k] == '\u{0}' {
-        buf.reset()
-        clean(last, first, k)
-      } else if s[k].to_char() is Some(c) && c.is_ascii() {
-        continue k + 1
-      } else {
-        match at_checked(s, k) {
-          Ok(d) => {
-            let next = k + length_utf16(d.to_int())
-            continue next
+  // Whether [first;last] can be returned as a plain substring copy.
+  fn is_clean(last, first) {
+    for k = first {
+      guard k <= last else {
+        // The view boundary at last + 1 must not land on the trailing
+        // half of a surrogate pair.
+        break last + 1 >= s.length() || !s[last + 1].is_trailing_surrogate()
+      }
+      let u = s[k]
+      guard u != '\u{0}' else { break false }
+      match u.to_char() {
+        Some(_) => continue k + 1
+        None =>
+          match at_checked(s, k) {
+            Ok(d) if k + 1 <= last => continue k + length_utf16(d.to_int())
+            _ => break false
           }
-          Err(_d) => {
-            buf.reset()
-            clean(last, first, k)
-          }
-        }
       }
     }
   }
@@ -157,12 +150,12 @@ pub fn utf_16_clean_raw(
   let max = s.length() - 1
   let last = @cmp.minimum(last, max)
   let first = @cmp.maximum(first, 0)
-  if pad == 0 {
-    return check(last, first, first)
+  if pad == 0 && is_clean(last, first) {
+    return s[first:last + 1].to_owned()
   }
   buf.reset()
   pad_it()
-  clean(last, first, first)
+  clean(last, first)
 }
 
 ///|
@@ -194,7 +187,19 @@ fn flush(
   k : Int,
 ) -> Unit {
   if start <= last {
-    buf.write_view(s[start:k])
+    for j = start {
+      guard j < k else { break }
+      match at_checked(s, j) {
+        Ok(c) => {
+          buf.write_char(c)
+          continue j + length_utf16(c.to_int())
+        }
+        Err(_) => {
+          buf.write_char(rep)
+          continue j + 1
+        }
+      }
+    }
   }
 }
 
@@ -351,15 +356,17 @@ fn _utf_16_clean_unesc_unref(
             continue start, next
           }
           match at_checked(s, k) {
-            Ok(d) => {
+            Ok(d) if k + length_utf16(d.to_int()) - 1 <= last => {
               let next = k + length_utf16(d.to_int())
               continue start, next
             }
-            Err(d) => {
-              let next = k + length_utf16(d)
+            // Unpaired surrogate, or a valid pair whose trailing half
+            // lies beyond [last]: emit U+FFFD and keep the span
+            // boundary, matching `utf_16_clean_raw`.
+            _ => {
               flush(last, start, k)
               buf.write_char(rep)
-              continue next, next
+              continue k + 1, k + 1
             }
           }
         }
@@ -372,7 +379,15 @@ fn _utf_16_clean_unesc_unref(
   let last = @cmp.minimum(last, max)
   let first = @cmp.maximum(first, 0)
   for k = first {
-    guard k <= last else { break s[first:last + 1].to_owned() }
+    guard k <= last else {
+      // The view boundary at last + 1 must not land on the trailing
+      // half of a surrogate pair.
+      if last + 1 < s.length() && s[last + 1].is_trailing_surrogate() {
+        buf.reset()
+        break resolve(last, first, last + 1)
+      }
+      break s[first:last + 1].to_owned()
+    }
     match (s[k], do_unesc) {
       ('\\', true) | ('&', _) | ('\u{0}', _) => {
         buf.reset()
@@ -383,11 +398,12 @@ fn _utf_16_clean_unesc_unref(
           continue k + 1
         }
         match at_checked(s, k) {
-          Ok(d) => {
+          Ok(d) if k + length_utf16(d.to_int()) - 1 <= last => {
             let next = k + length_utf16(d.to_int())
             continue next
           }
-          Err(_d) => {
+          // Unpaired surrogate, or a pair cut by the end of the span.
+          _ => {
             buf.reset()
             break resolve(last, first, k)
           }

--- a/src/char/text_test.mbt
+++ b/src/char/text_test.mbt
@@ -517,3 +517,88 @@ test "sub_includes repeated pattern match" {
     content="true",
   )
 }
+
+///|
+fn string_of_code_units(units : Array[Int]) -> String {
+  let b = StringBuilder::new()
+  for u in units {
+    b.write_char(u.unsafe_to_char())
+  }
+  b.to_string()
+}
+
+///|
+test "prev_char returns the immediately preceding char" {
+  // BMP chars are single UTF-16 units: the old implementation scanned
+  // backwards for UTF-8 lead bytes and returned the wrong char.
+  inspect(@char.prev_char("aж*", first=0, before=2), content="ж")
+  inspect(@char.prev_char("a😀*", first=0, before=3), content="😀")
+  inspect(@char.prev_char("ab", first=0, before=1), content="a")
+  inspect(@char.prev_char("ab", first=1, before=1), content=" ")
+}
+
+///|
+test "prev_char and next_char on unpaired surrogates" {
+  let lone_trail = string_of_code_units(['a'.to_int(), 0xDC00, '*'.to_int()])
+  inspect(@char.prev_char(lone_trail, first=0, before=2), content="�")
+  inspect(@char.next_char(lone_trail, last=2, after=0), content="�")
+  let lone_lead = string_of_code_units(['a'.to_int(), 0xD800, '*'.to_int()])
+  inspect(@char.prev_char(lone_lead, first=0, before=2), content="�")
+  inspect(@char.next_char(lone_lead, last=2, after=0), content="�")
+}
+
+///|
+test "prev_char and next_char out-of-range arguments" {
+  inspect(@char.prev_char("ab", first=0, before=99), content=" ")
+  inspect(@char.prev_char("ab", first=-5, before=0), content=" ")
+  inspect(@char.next_char("ab", last=99, after=10), content=" ")
+}
+
+///|
+test "at_checked out of bounds and unpaired surrogates" {
+  debug_inspect(@char.at_checked("a", 5), content="Err(0)")
+  debug_inspect(@char.at_checked("a", -1), content="Err(0)")
+  // A leading surrogate must be followed by a trailing surrogate.
+  let lead_then_ascii = string_of_code_units([0xD800, 'a'.to_int()])
+  debug_inspect(@char.at_checked(lead_then_ascii, 0), content="Err(55296)")
+}
+
+///|
+test "utf_16_clean_raw with unpaired surrogates" {
+  let buf = StringBuilder::new()
+  let lone = string_of_code_units([0xDC00])
+  inspect(@char.utf_16_clean_raw(buf, lone, first=0, last=0), content="�")
+  let mixed = string_of_code_units(['a'.to_int(), 0xDC00, 'b'.to_int()])
+  inspect(@char.utf_16_clean_raw(buf, mixed, first=0, last=2), content="a�b")
+  // A span that cuts a surrogate pair in half.
+  let emoji = "😀"
+  inspect(@char.utf_16_clean_raw(buf, emoji, first=0, last=0), content="�")
+  // A clean span followed by an unpaired trailing surrogate: the span
+  // boundary must not abort.
+  let clean_then_trail = string_of_code_units(['a'.to_int(), 0xDC00])
+  inspect(
+    @char.utf_16_clean_raw(buf, clean_then_trail, first=0, last=0),
+    content="a",
+  )
+}
+
+///|
+test "utf_16_clean_unref preserves the span boundary on a cut pair" {
+  let buf = StringBuilder::new()
+  // The span [0,0] ends on the leading half of "😀"; the trailing unit
+  // is outside the span and must not leak into the output (it becomes
+  // U+FFFD, matching utf_16_clean_raw).
+  inspect(@char.utf_16_clean_unref(buf, "😀", first=0, last=0), content="�")
+  inspect(
+    @char.utf_16_clean_unesc_unref(buf, "😀", first=0, last=0),
+    content="�",
+  )
+  // The full pair within the span is preserved.
+  inspect(
+    @char.utf_16_clean_unref(buf, "😀", first=0, last=1),
+    content="😀",
+  )
+  // A lone trailing surrogate also becomes U+FFFD.
+  let lone = string_of_code_units(['a'.to_int(), 0xDC00])
+  inspect(@char.utf_16_clean_unref(buf, lone, first=0, last=1), content="a�")
+}

--- a/src/cmark/block.mbt
+++ b/src/cmark/block.mbt
@@ -197,15 +197,18 @@ pub fn CodeBlock::make_fence(self : CodeBlock) -> (Char, Count) {
 pub fn CodeBlock::language_of_info_string(s : String) -> (String, String)? {
   guard !s.is_empty() else { None }
   let max = s.length() - 1
+  // ASCII whitespace is a single code unit, so scan code units: indexing
+  // chars with `get_char` aborts on the trailing half of a surrogate pair.
   let white = for i = 0; ; i = i + 1 {
-    if i > max || @char.is_ascii_whitespace(s.get_char(i).unwrap()) {
+    if i > max || (s[i].to_char() is Some(c) && @char.is_ascii_whitespace(c)) {
       break i
     }
   }
   let rem_first = @cmark_base.first_non_blank(s, last=max, start=white)
-  let lang = s[0:white].to_owned()
+  let buf = StringBuilder::new()
+  let lang = @char.utf_16_clean_raw(buf, s, first=0, last=white - 1)
   guard !lang.is_empty() else { None }
-  Some((lang, s[rem_first:max + 1].to_owned()))
+  Some((lang, @char.utf_16_clean_raw(buf, s, first=rem_first, last=max)))
 }
 
 ///|

--- a/src/cmark/parser.mbt
+++ b/src/cmark/parser.mbt
@@ -34,6 +34,24 @@ priv struct Parser {
 }
 
 ///|
+fn assert_well_formed_utf16_input(i : String) -> Unit {
+  for k = 0 {
+    guard k < i.length() else { break }
+    let u = i[k]
+    if u.is_leading_surrogate() {
+      guard k + 1 < i.length() && i[k + 1].is_trailing_surrogate() else {
+        abort("cmark parser input must be well-formed UTF-16")
+      }
+      continue k + 2
+    }
+    guard !u.is_trailing_surrogate() else {
+      abort("cmark parser input must be well-formed UTF-16")
+    }
+    continue k + 1
+  }
+}
+
+///|
 fn Parser::new(
   defs? : LabelDefs = Map([]),
   resolver? : LabelResolverFn = LabelContext::default_resolver,
@@ -45,6 +63,7 @@ fn Parser::new(
   strict? : Bool = true,
   i : String,
 ) -> Parser {
+  assert_well_formed_utf16_input(i)
   {
     file,
     i,

--- a/src/cmark_base/autolink.mbt
+++ b/src/cmark_base/autolink.mbt
@@ -53,14 +53,19 @@ pub fn autolink_uri(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
   let char_is_scheme = fn(c) {
     @char.is_ascii_alphanum(c) || c is ('+' | '-' | '.')
   }
-  let char_is_uri = fn(c : Char) {
-    !(c is ('\u{0}'..='\u{1f}' | '\u{7f}' | '<' | '>' | ' '))
+  // Code units outside the excluded ASCII set are URI chars; surrogate
+  // halves belong to non-ASCII chars, which are allowed.
+  let unit_is_uri = fn(u : UInt16) {
+    match u.to_char() {
+      Some(c) => !(c is ('\u{0}'..='\u{1f}' | '\u{7f}' | '<' | '>' | ' '))
+      None => true
+    }
   }
   let rest = fn(s : String, last, k) {
     for k in k..<=last {
-      let sk = s.get_char(k).unwrap()
-      guard !char_is_uri(sk) else { continue }
-      break if sk == '>' { Some(k) } else { None }
+      let u = s[k]
+      guard !unit_is_uri(u) else { continue }
+      break if u == '>' { Some(k) } else { None }
     } nobreak {
       None
     }
@@ -68,12 +73,13 @@ pub fn autolink_uri(s : String, last? : Int = -1, start? : Int = 0) -> Last? {
   let next = start + 1
   guard next <= last &&
     s[start] == '<' &&
-    s.get_char(next).unwrap().is_ascii_alphabetic() else {
+    s[next].to_char() is Some(first_scheme_char) &&
+    first_scheme_char.is_ascii_alphabetic() else {
     return None
   }
   for c = 1, k = next + 1 {
     guard k <= last else { break None }
-    let sk = s.get_char(k).unwrap()
+    guard s[k].to_char() is Some(sk) else { break None }
     if char_is_scheme(sk) && c <= 32 {
       continue c + 1, k + 1
     }

--- a/src/cmark_base/leaf_blocks.mbt
+++ b/src/cmark_base/leaf_blocks.mbt
@@ -398,7 +398,16 @@ pub fn LineType::html_block_start(
         }
         continue i + 1
       }
-      let tag = s[tag_first:tag_last + 1].to_owned().to_lower()
+      // The tag name is ASCII alphabetic: build it from code units. A
+      // view boundary at tag_last + 1 could land on an unpaired
+      // surrogate and abort.
+      let tag = {
+        let b = StringBuilder::new(size_hint=tag_last - tag_first + 1)
+        for i in tag_first..<=tag_last {
+          b.write_char(@char.to_ascii_lower(s[i].unsafe_to_char()))
+        }
+        b.to_string()
+      }
       let is_open_end = {
         let n = tag_last + 1
         n > last ||
@@ -409,7 +418,11 @@ pub fn LineType::html_block_start(
         | 62)
       }
       let is_open_close_end = is_open_end ||
-        (tag_last + 2 <= last && s[tag_last + 1:tag_last + 3] == "/>")
+        (
+          tag_last + 2 <= last &&
+          s[tag_last + 1] == '/' &&
+          s[tag_last + 2] == '>'
+        )
       if c != '/' {
         if html_start_cond_1_set.contains(tag) && is_open_end {
           HtmlBlockLine(EndCond1) // 1
@@ -439,19 +452,18 @@ fn LineType::html_block_end_cond_1(
     guard k + 3 <= last else { break false }
     guard s[k] == '<' && s[k + 1] == '/' else { continue k + 1 }
     let next = k + 2
-    let is_end_tag = {
-      let lower_s_sub = lower_s[next:]
-      match s[next] {
-        'p' => lower_s_sub.has_prefix("pre>")
-        's' =>
-          if s[k + 3] == 't' {
-            lower_s_sub.has_prefix("style>")
-          } else {
-            lower_s_sub.has_prefix("script>")
-          }
-        't' => lower_s_sub.has_prefix("textarea>")
-        _ => false
-      }
+    // Only create the view once the unit at `next` is a known ASCII
+    // char: a view boundary on an unpaired surrogate aborts.
+    let is_end_tag = match s[next] {
+      'p' => lower_s[next:].has_prefix("pre>")
+      's' =>
+        if s[k + 3] == 't' {
+          lower_s[next:].has_prefix("style>")
+        } else {
+          lower_s[next:].has_prefix("script>")
+        }
+      't' => lower_s[next:].has_prefix("textarea>")
+      _ => false
     }
     guard !is_end_tag else { break true }
     continue k + 1

--- a/src/cmark_base/link.mbt
+++ b/src/cmark_base/link.mbt
@@ -182,13 +182,17 @@ pub fn[A] link_label(
     if @char.is_ascii_blank(prev) && !b.is_empty() {
       b.write_char(' ')
     }
-    let mut u = s.get_char(k).unwrap()
+    // Indices are UTF-16 code units, so advance by the char's UTF-16
+    // length; unpaired surrogates normalize to U+FFFD.
+    let mut u = match @char.at_checked(s, k) {
+      Ok(c) => c
+      Err(_) => @char.rep
+    }
     if u == '\u{0}' {
       u = @char.rep
     }
-    let k1 = k + @char.length_utf8(u.to_int())
+    let k1 = k + @char.length_utf16(u.to_int())
     b.write_char(@char.to_ascii_lower(u))
-    let prev = s[k].unsafe_to_char()
-    continue line, prev, start, count + 1, k1
+    continue line, u, start, count + 1, k1
   }
 }

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -158,12 +158,46 @@ fn joined_string(c : Context, join : Joined[String]) -> Unit {
 // }
 
 ///|
+/// Writes `s[start:end)` to `b`. A span free of surrogate code units is
+/// well-formed and its boundaries cannot split a pair, so it is bulk
+/// copied. Otherwise it is written one character at a time, emitting
+/// U+FFFD for any unpaired surrogate. This avoids the abort that a view
+/// boundary on a surrogate half would cause and keeps output well-formed
+/// even for a programmatically built, unsanitized document.
+fn write_span(b : StringBuilder, s : String, start : Int, end : Int) -> Unit {
+  guard start < end && start < s.length() else { return }
+  let has_surrogate = for k = start {
+    guard k < end else { break false }
+    let u = s[k].to_int()
+    guard !(0xD800 <= u && u <= 0xDFFF) else { break true }
+    continue k + 1
+  }
+  if !has_surrogate {
+    b.write_view(s[start:end])
+  } else {
+    for k = start {
+      guard k < end else { break }
+      match @char.at_checked(s, k) {
+        Ok(c) => {
+          b.write_char(c)
+          continue k + @char.length_utf16(c.to_int())
+        }
+        Err(_) => {
+          b.write_char(@char.rep)
+          continue k + 1
+        }
+      }
+    }
+  }
+}
+
+///|
 fn buffer_add_html_escaped_string(b : StringBuilder, s : String) -> Unit {
   let len = s.length()
   let max_idx = len - 1
   fn flush(b : StringBuilder, start : Int, i : Int) {
     if start < len {
-      b.write_view(s[start:i])
+      write_span(b, s, start, i)
     }
   }
 
@@ -244,15 +278,35 @@ fn buffer_add_pct_encoded_string(b : StringBuilder, s : String) -> Unit { // Per
     | '@')
   }
 
-  let flush = fn(b : StringBuilder, max : Int, start : Int, i : Int) -> Unit {
-    if start <= max {
-      b.write_view(s[start:i])
+  fn pct_byte(b : StringBuilder, byte : Int) {
+    b.write_char('%')
+    b.write_char(unsafe_hexdigit((byte >> 4) & 0xF))
+    b.write_char(unsafe_hexdigit(byte & 0xF))
+  }
+
+  // Percent-encodes the UTF-8 bytes of code point [cp].
+  fn pct_utf8(b : StringBuilder, cp : Int) {
+    if cp < 0x80 {
+      pct_byte(b, cp)
+    } else if cp < 0x800 {
+      pct_byte(b, 0xC0 | (cp >> 6))
+      pct_byte(b, 0x80 | (cp & 0x3F))
+    } else if cp < 0x10000 {
+      pct_byte(b, 0xE0 | (cp >> 12))
+      pct_byte(b, 0x80 | ((cp >> 6) & 0x3F))
+      pct_byte(b, 0x80 | (cp & 0x3F))
+    } else {
+      pct_byte(b, 0xF0 | (cp >> 18))
+      pct_byte(b, 0x80 | ((cp >> 12) & 0x3F))
+      pct_byte(b, 0x80 | ((cp >> 6) & 0x3F))
+      pct_byte(b, 0x80 | (cp & 0x3F))
     }
   }
+
   let max = s.length() - 1
   for start = 0, i = 0 {
     if i > max {
-      flush(b, max, start, i)
+      write_span(b, s, start, i)
       break
     }
     let next = i + 1
@@ -260,24 +314,29 @@ fn buffer_add_pct_encoded_string(b : StringBuilder, s : String) -> Unit { // Per
       c if c.to_char() is Some(c) && (@char.is_ascii_alphanum(c) || is_delim(c)) =>
         continue start, next
       '&' => {
-        flush(b, max, start, i)
+        write_span(b, s, start, i)
         b.write_string("&amp;")
         continue next, next
       }
       '\'' => {
-        flush(b, max, start, i)
+        write_span(b, s, start, i)
         b.write_string("&apos;")
         continue next, next
       }
-      c => {
-        flush(b, max, start, i)
-        let c_int = c.to_int()
-        let hi = (c_int >> 4) & 0xF
-        let lo = c_int & 0xF
-        b.write_char('%')
-        b.write_char(unsafe_hexdigit(hi))
-        b.write_char(unsafe_hexdigit(lo))
-        continue next, next
+      _ => {
+        write_span(b, s, start, i)
+        match @char.at_checked(s, i) {
+          Ok(d) => {
+            pct_utf8(b, d.to_int())
+            let next = i + @char.length_utf16(d.to_int())
+            continue next, next
+          }
+          // Unpaired surrogate: encode U+FFFD.
+          Err(_) => {
+            pct_utf8(b, @char.rep.to_int())
+            continue next, next
+          }
+        }
       }
     }
   }

--- a/src/cmark_html/html_wbtest.mbt
+++ b/src/cmark_html/html_wbtest.mbt
@@ -58,3 +58,49 @@ test "buffer_add_pct_encoded_string with ampersand" {
   buffer_add_pct_encoded_string(b, "test&test") // This will trigger line 211 for "&" handling
   inspect(b.to_string(), content="test&amp;test")
 }
+
+///|
+fn wb_string_of_code_units(units : Array[Int]) -> String {
+  let b = StringBuilder::new()
+  for u in units {
+    b.write_char(u.unsafe_to_char())
+  }
+  b.to_string()
+}
+
+///|
+/// `write_span`'s fast path must not bulk-copy a span that contains a
+/// lone surrogate. `Parser::new` may sanitize user input, but callers can
+/// also build `Doc` values directly.
+test "html escape sanitizes a lone leading surrogate" {
+  let b = StringBuilder::new()
+  buffer_add_html_escaped_string(b, wb_string_of_code_units([0xD800]))
+  inspect(b.to_string(), content="�")
+  b.reset()
+  buffer_add_html_escaped_string(
+    b,
+    wb_string_of_code_units(['a'.to_int(), 0xD800, 'b'.to_int()]),
+  )
+  inspect(b.to_string(), content="a�b")
+  b.reset()
+  buffer_add_html_escaped_string(b, "a😀b")
+  inspect(b.to_string(), content="a😀b")
+}
+
+///|
+test "pct encode sanitizes a lone leading surrogate" {
+  let b = StringBuilder::new()
+  buffer_add_pct_encoded_string(
+    b,
+    wb_string_of_code_units(['a'.to_int(), 0xD800]),
+  )
+  // U+FFFD percent-encoded as UTF-8 bytes.
+  inspect(b.to_string(), content="a%EF%BF%BD")
+}
+
+///|
+test "pct encode writes UTF-8 bytes for non-ASCII chars" {
+  let b = StringBuilder::new()
+  buffer_add_pct_encoded_string(b, "世😀")
+  inspect(b.to_string(), content="%E4%B8%96%F0%9F%98%80")
+}

--- a/src/cmark_html/utf16_invariant_test.mbt
+++ b/src/cmark_html/utf16_invariant_test.mbt
@@ -1,0 +1,30 @@
+// Regression tests for the parser's well-formed UTF-16 input invariant.
+
+///|
+fn string_of_code_units(units : Array[Int]) -> String {
+  let b = StringBuilder::new()
+  for u in units {
+    b.write_char(u.unsafe_to_char())
+  }
+  b.to_string()
+}
+
+///|
+test "valid astral input renders normally" {
+  inspect(@cmark_html.render("😀"), content="<p>😀</p>\n")
+}
+
+///|
+test "panic parser rejects lone leading surrogate" {
+  ignore(@cmark_html.render(string_of_code_units([0xD800])))
+}
+
+///|
+test "panic parser rejects lone trailing surrogate" {
+  ignore(@cmark_html.render(string_of_code_units([0xDC00])))
+}
+
+///|
+test "panic parser rejects leading surrogate not followed by trailing surrogate" {
+  ignore(@cmark_html.render(string_of_code_units([0xD800, 'a'.to_int()])))
+}

--- a/src/cmark_html/utf16_regression_test.mbt
+++ b/src/cmark_html/utf16_regression_test.mbt
@@ -1,0 +1,43 @@
+// Regression tests for valid non-BMP Unicode at UTF-16 boundaries.
+
+///|
+/// `language_of_info_string` must scan by UTF-16 code units, not use a
+/// code-unit index as a character index.
+test "astral char in fence info string" {
+  inspect(
+    @cmark_html.render("```😀\nx\n```"),
+    content="<pre><code class=\"language-😀\">x\n</code></pre>\n",
+  )
+  inspect(
+    @cmark_html.render("```a😀 b\nx\n```"),
+    content="<pre><code class=\"language-a😀\">x\n</code></pre>\n",
+  )
+}
+
+///|
+/// `autolink_uri` used to step one UTF-16 code unit at a time with
+/// `get_char`, landing on the trailing half of a surrogate pair.
+test "astral char in autolink" {
+  inspect(
+    @cmark_html.render("<http://a😀>"),
+    content="<p><a href=\"http://a%F0%9F%98%80\">http://a😀</a></p>\n",
+  )
+}
+
+///|
+/// Link label normalization must advance by UTF-16 length, not UTF-8
+/// byte length.
+test "astral char in link label" {
+  inspect(
+    @cmark_html.render("[😀]: /x\n\n[😀]"),
+    content="<p><a href=\"/x\">😀</a></p>\n",
+  )
+}
+
+///|
+/// HTML block start detection must avoid slices whose boundaries can land
+/// inside a surrogate pair.
+test "astral char after html tag name" {
+  inspect(@cmark_html.render("<d.😀"), content="<p>&lt;d.😀</p>\n")
+  inspect(@cmark_html.render("<div😀>"), content="<p>&lt;div😀&gt;</p>\n")
+}


### PR DESCRIPTION
## Summary

- Assert in `Parser::new` that parser input is well-formed UTF-16
- Panic with a clear message on unpaired surrogate code units instead of silently repairing invalid input
- Add black-box renderer tests documenting valid astral input and malformed-surrogate panic cases

## Scope

This is the parser-boundary invariant slice extracted from #127. It intentionally avoids adding a public sanitizer API: the parser maintains the invariant that its MoonBit `String` input is well-formed, and malformed surrogate code-unit sequences are treated as programmer error from unsafe or host-side construction.

This PR is stacked after #135 because the earlier PRs fix the shared UTF-16 helpers, renderer handling, and valid-Unicode scanner indexing.

Dependency order: #132 -> #134 -> #135 -> this PR.

## Validation

- `moon test src/cmark_html --target wasm-gc`
- `moon check --warn-list +unnecessary_annotation`
- `moon test`
- `moon info`