### PR TITLE
fix: change render() safe default to true (CWE-79)

### DIFF
--- a/src/cmark_html/README.mbt.md
+++ b/src/cmark_html/README.mbt.md
@@ -3,7 +3,7 @@
 This package provides basic facilities for rendering CommonMark documents as HTML.
 It also serves as a concrete implementation example for the `cmark_renderer` abstraction.
 
-To use this package in a quick way, you can use the `@cmark_html.render!` function:
+To use this package in a quick way, you can use the `@cmark_html.render` function:
 
 ```mbt check
 ///|
@@ -12,7 +12,7 @@ test "basic rendering" {
     #|# Hello World
     #|
     #|This is a paragraph.
-  let rendered = @cmark_html.render(safe=false, strict=false, doc)
+  let rendered = @cmark_html.render(strict=false, doc)
   inspect(
     rendered,
     content=(
@@ -24,7 +24,37 @@ test "basic rendering" {
 }
 ```
 
-To convert a `cmark` syntax tree to HTML, you can use the `@cmark_html.from_doc` function like so:
+## Safe rendering and compatibility
+
+`render` enables `safe=true` by default. Raw HTML blocks and inline tags are
+replaced by comments, and link/image destinations rejected by the existing
+unsafe-URL check (such as `javascript:` and `vbscript:`) become empty strings.
+Ordinary Markdown, HTTPS links, and escaped code remain available.
+
+This is a behavior change from the previous `safe=false` default. Callers that
+need raw HTML passthrough must explicitly pass `safe=false` and should only do
+so for trusted input. Explicit `safe=true` and `safe=false` retain their existing
+behavior. Safe mode omits raw HTML; it is not a general-purpose HTML sanitizer.
+
+```mbt check
+///|
+test "safe default and trusted HTML opt in" {
+  inspect(
+    @cmark_html.render("<div>trusted HTML</div>"),
+    content="<!--CommonMark HTML block omitted-->\n",
+  )
+  inspect(
+    @cmark_html.render(safe=false, "<div>trusted HTML</div>"),
+    content="<div>trusted HTML</div>\n",
+  )
+}
+```
+
+## Rendering a parsed document
+
+The lower-level `from_doc`, `renderer`, and `xhtml_renderer` APIs still require
+an explicit `safe` argument; this change only affects the default of `render`.
+To convert a `cmark` syntax tree to HTML, use `@cmark_html.from_doc`:
 
 ```mbt check
 ///|
@@ -37,7 +67,7 @@ test "rendering from @cmark.Doc" {
       #|This is a paragraph.
     ),
   )
-  let rendered = @cmark_html.from_doc(safe=false, doc)
+  let rendered = @cmark_html.from_doc(safe=true, doc)
   inspect(
     rendered,
     content=(

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -1022,7 +1022,7 @@ pub fn from_doc(
 /// For more parsing options, call `@cmark.Doc::from_string()` and `from_doc()` manually.
 pub fn render(
   backend_blocks? : Bool = false,
-  safe? : Bool = false,
+  safe? : Bool = true,
   strict? : Bool = true,
   s : String,
 ) -> String raise {

--- a/src/cmark_html/html.mbt
+++ b/src/cmark_html/html.mbt
@@ -977,7 +977,8 @@ fn doc(c : Context, d : Doc) -> Bool raise {
 ///
 /// Parameters:
 ///
-/// - `safe` — when `true`, unsafe raw HTML and links are replaced by comments.
+/// - `safe` — when `true`, raw HTML is replaced by comments and unsafe
+///   link and image destinations are cleared.
 /// - `backend_blocks` — when `true`, fenced code blocks whose info string
 ///   starts with `=` are treated as backend-specific blocks (e.g. `=html`).
 pub fn renderer(
@@ -1018,6 +1019,14 @@ pub fn from_doc(
 
 ///|
 /// Render CommonMark String to HTML with the default parsing preferences.
+///
+/// Safe mode is enabled by default: raw HTML is replaced by comments and
+/// unsafe link and image destinations are cleared. Pass `safe=false` only
+/// for trusted input when raw HTML passthrough is required.
+///
+/// Compatibility: the default for `safe` was previously `false`. This changes
+/// rendered output for callers that omit the argument; explicit `safe` values
+/// retain their behavior. The lower-level rendering APIs still require `safe`.
 ///
 /// For more parsing options, call `@cmark.Doc::from_string()` and `from_doc()` manually.
 pub fn render(

--- a/src/cmark_html/safe_default_test.mbt
+++ b/src/cmark_html/safe_default_test.mbt
@@ -1,0 +1,60 @@
+///|
+test "render defaults to omitting raw HTML" {
+  for
+    case in [
+      ("<script>alert(1)</script>", "<!--CommonMark HTML block omitted-->\n"),
+      (
+        "before <img src=x onerror=alert(1)> after", "<p>before <!--CommonMark raw HTML omitted--> after</p>\n",
+      ),
+    ] {
+    let (input, expected) = case
+    assert_eq(@cmark_html.render(input), expected)
+    assert_eq(@cmark_html.render(input), @cmark_html.render(safe=true, input))
+  }
+}
+
+///|
+test "render defaults to removing unsafe link and image destinations" {
+  for
+    destination in [
+      "javascript:alert(1)", "JaVaScRiPt:alert(1)", "javascript&#58;alert(1)", "vbscript:msgbox(1)",
+      "file:///tmp/test", "data:text/html,test",
+    ] {
+    let link = "[link](\{destination})"
+    assert_eq(@cmark_html.render(link), "<p><a href=\"\">link</a></p>\n")
+    assert_eq(@cmark_html.render(link), @cmark_html.render(safe=true, link))
+    assert_eq(
+      @cmark_html.render("![image](\{destination})"),
+      "<p><img src=\"\" alt=\"image\" ></p>\n",
+    )
+  }
+}
+
+///|
+test "render safe false preserves explicit HTML and link opt in" {
+  assert_eq(
+    @cmark_html.render(safe=false, "<script>alert(1)</script>"),
+    "<script>alert(1)</script>\n",
+  )
+  assert_eq(
+    @cmark_html.render(safe=false, "before <img src=x onerror=alert(1)> after"),
+    "<p>before <img src=x onerror=alert(1)> after</p>\n",
+  )
+  for destination in ["javascript:alert(1)", "vbscript:msgbox(1)"] {
+    assert_eq(
+      @cmark_html.render(safe=false, "[link](\{destination})"),
+      "<p><a href=\"\{destination}\">link</a></p>\n",
+    )
+  }
+}
+
+///|
+test "render safe default preserves ordinary Markdown" {
+  for
+    destination in ["https://example.com", "/relative", "mailto:a@example.com"] {
+    assert_eq(
+      @cmark_html.render("[link](\{destination}) **😀** `<script>`"),
+      "<p><a href=\"\{destination}\">link</a> <strong>😀</strong> <code>&lt;script&gt;</code></p>\n",
+    )
+  }
+}


### PR DESCRIPTION
## Summary

- Change `render()`'s `safe` default from `false` to `true`
- By default, omit raw HTML blocks and inline HTML, and clear link/image destinations rejected by the existing unsafe-URL check
- Preserve explicit `safe=false` behavior for callers that intentionally render trusted raw HTML
- Add public-API regressions for the new default, explicit opt-out, dangerous link/image destinations, and ordinary Markdown
- Document the compatibility change and update README examples to use safe rendering

## Compatibility and scope

This is a behavior change for callers that omit `safe`. Callers that intentionally need raw HTML passthrough must explicitly pass `safe=false` and should only do so for trusted input. Explicit `safe=true` and `safe=false` retain their existing behavior. The lower-level `from_doc`, `renderer`, and `xhtml_renderer` APIs still require an explicit `safe` argument.

The URL filtering rules are unchanged. Unsafe link/image destinations are cleared, not replaced by comments. Safe mode omits raw HTML; it is not a general-purpose HTML sanitizer. No public signatures or generated interfaces changed.

Rebased onto `main` at `1d78634` (including #132, #134, and #135). The original author's default-value change is preserved as a separate commit, followed by tests and documentation.

## Validation

- Negative control: temporarily restore `safe=false`; the two default-filtering tests fail, while explicit opt-out and ordinary-Markdown tests pass
- `moon test src/cmark_html --target wasm-gc` — 38/38 passed with the new default
- `moon check --warn-list +73` — 0 errors; deprecation warnings remain
- `moon test --target wasm-gc` — 391/391 passed
- `moon test --target wasm` — 391/391 passed
- `moon test --target js` — 391/391 passed
- `moon test --target native` — 394/394 passed
- `moon info` — generated interfaces unchanged
- `moon fmt` and `git diff --check`
