### PR TITLE
chore: bump version to 0.4.8

### DIFF
--- a/moon.mod
+++ b/moon.mod
@@ -1,6 +1,6 @@
 name = "moonbit-community/cmark"
 
-version = "0.4.7"
+version = "0.4.8"
 
 import {
   "moonbit-community/casefold@0.1.5",


### PR DESCRIPTION
## Summary

Bump `moonbit-community/cmark` from `0.4.7` to `0.4.8` following the repository's patch-version update convention. This PR only changes the version in `moon.mod`; dependencies and generated interfaces are unchanged.

The release includes the already-merged closer-index optimization (#129), parser EOF guards (#133), UTF-16 fixes (#132, #134, #135), and safer HTML rendering defaults (#137).

## Compatibility note

`render()` now defaults to `safe=true`: raw HTML is omitted, and link/image destinations rejected by the existing unsafe-URL check are cleared. Callers requiring trusted raw HTML passthrough must explicitly pass `safe=false`. This is a behavior change for callers that previously omitted the argument; it is not a general-purpose HTML sanitizer.

## Validation

- `moon check --warn-list +73`: passed (existing warnings remain).
- `moon test --target wasm-gc`: 391 passed.
- `moon test --target wasm`: 391 passed.
- `moon test --target js`: 391 passed.
- `moon test --target native`: 394 passed.
- `moon info`, `moon fmt`, and `git diff --check`: passed; generated interfaces unchanged.

Package publication is intentionally not triggered by this PR. The existing `publish-package` workflow remains a separate manual step after merge.
